### PR TITLE
fix(ci): tolerate fully-excluded diffs in pr-commit-size grep

### DIFF
--- a/.github/workflows/pr-commit-size.yml
+++ b/.github/workflows/pr-commit-size.yml
@@ -31,7 +31,7 @@ jobs:
           if [ -f "$EXCLUDES_FILE" ]; then
             PATTERN=$(grep -v -E '^\s*(#|$)' "$EXCLUDES_FILE" | paste -sd '|' -)
             if [ -n "$PATTERN" ]; then
-              FILTERED=$(echo "$STATS" | grep -v -E "$PATTERN")
+              FILTERED=$(echo "$STATS" | grep -v -E "$PATTERN" || true)
             else
               FILTERED="$STATS"
             fi


### PR DESCRIPTION
## Summary

- **Root cause**: `.github/workflows/pr-commit-size.yml` uses `grep -v -E "$PATTERN"` inside a `set -e` shell. When 100% of the diff is in excluded files (e.g. only `pnpm-lock.yaml`), `grep -v` finds no matches, exits `1`, and kills the step — falsely marking the PR oversized.
- **Fix**: append `|| true` so an empty result is treated as success.
- **Impact**: unblocks Dependabot PR #244 (postcss `8.5.9 → 8.5.14`, includes XSS and arbitrary-file-read patches).

## Test plan

- [ ] `Commit Size Check` passes on this PR (1 file, 1 line changed)
- [ ] After merge, comment `@dependabot rebase` on PR #244 — expect all checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the build workflow's error handling to gracefully manage edge cases during the filtering process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Vijay431/additional-context-menus/pull/246?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->