### PR TITLE
chore(ci): simplify build matrix to ubuntu × node 22/24/26 × VS Code stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,14 +92,12 @@ jobs:
 
   build:
     name: Build
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     needs: [test-unit, test-integration]
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: ['22.x', '24.x', '26.x']
-        vscode-version: ['stable', 'insiders']
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -121,4 +119,4 @@ jobs:
       - name: Build Extension
         run: pnpm run build
         env:
-          VSCODE_VERSION: ${{ matrix.vscode-version }}
+          VSCODE_VERSION: stable

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ Thumbs.db
 TODO.md
 CHANGELOG_RELEASE.md
 IMPLEMENTATION_SUMMARY.md
+.antigravitycli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **CI build matrix simplified**: Build job now runs Ubuntu-only with VS Code stable across Node 22/24/26. Removed Windows, macOS, and VS Code Insiders matrix dimensions to reduce CI cost and noise.
 - **Removed GitHub Pages site**: Deleted the `docs/` Jekyll site in favour of `README.md` as the single user-facing source. All `vijay431.github.io` links removed across the codebase.
 - **Single source of truth established**: `package.json` `contributes` is canonical for command/setting/keybinding metadata; `README.md` is canonical for user-facing narrative; `CLAUDE.md` is canonical for architecture and dev conventions.
 - **package.json scripts**: Removed `docs:serve` and `docs:live`; simplified `system:verify` to `husky` only (docs/Jekyll bundle setup removed).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -283,7 +283,7 @@ This project follows [SemVer 2.0.0](https://semver.org/spec/v2.0.0.html). Pre-re
 
 ### Automation Layout
 
-- `.github/workflows/ci.yml` runs PR/main quality gates: lint, unit coverage, integration tests, build matrix, audit, and dependency review.
+- `.github/workflows/ci.yml` runs PR/main quality gates: lint, unit coverage, integration tests, build (Ubuntu × Node 22/24/26 × VS Code stable), audit, and dependency review.
 - `.github/workflows/release.yml` runs only on `v*` tag pushes: package, verify, publish to VS Code Marketplace and Open VSX, and create a GitHub Release.
 - Community automation lives in `.github/workflows/stale.yml`, `.github/workflows/labels-sync.yml`, and `.github/workflows/all-contributors.yml`.
 - Release publishing requires `VSCE_PAT` and `OVSX_PAT`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,7 +215,7 @@ The repository separates quality gates, release publishing, and community automa
 - `lint` — runs `pnpm run lint`
 - `test-unit` — runs `pnpm run test:unit:coverage`
 - `test-integration` — runs `pnpm run test:integration` (Mocha + VS Code, Ubuntu, after `lint`, parallel with `test-unit`)
-- `build` — builds on Ubuntu, Windows, macOS × Node 20/22/24 × VS Code stable/insiders (after both test jobs pass)
+- `build` — builds on Ubuntu × Node 22/24/26 × VS Code stable (after both test jobs pass)
 - `audit` — runs `pnpm audit --audit-level=high`
 - `dependency-review` — reviews dependency changes on PRs
 


### PR DESCRIPTION
## Summary

- Simplifies CI build matrix from 18 combinations (3 OS × 3 Node × 2 VS Code) to 3 (Ubuntu × Node 22/24/26 × VS Code stable)
- Removes Windows, macOS, and VS Code Insiders dimensions from the `build` job
- Adds `.antigravitycli` to `.gitignore`
- Updates `CONTRIBUTING.md`, `CLAUDE.md`, and `CHANGELOG.md` to reflect new matrix

## Test plan

- [ ] CI passes on this PR (lint → unit → integration → build ×3)
- [ ] No regressions in existing jobs (lint, test-unit, test-integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)