### PR TITLE
fix(ci): resolve Node 24 incompatibilities in release workflow

### DIFF
--- a/.github/workflows/all-contributors.yml
+++ b/.github/workflows/all-contributors.yml
@@ -35,7 +35,15 @@ jobs:
           node-version: '22.x'
           cache: pnpm
 
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-node22.x-${{ hashFiles('pnpm-lock.yaml') }}
+
       - name: Install Dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Add Requested Contributor

--- a/.github/workflows/all-contributors.yml
+++ b/.github/workflows/all-contributors.yml
@@ -22,17 +22,17 @@ jobs:
       )
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install PNPM
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
-          version: 10
+          standalone: true
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '24.x'
+          node-version: '22.x'
           cache: pnpm
 
       - name: Install Dependencies

--- a/.github/workflows/labels-sync.yml
+++ b/.github/workflows/labels-sync.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Sync Labels
         uses: EndBug/label-sync@v2

--- a/.github/workflows/pr-commit-size.yml
+++ b/.github/workflows/pr-commit-size.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24.x'
+          node-version: '22.x'
           cache: pnpm
 
       - name: Install Dependencies
@@ -162,14 +162,14 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24.x'
+          node-version: '22.x'
 
       - name: Publish to VS Code Marketplace
         run: |
           if [ "${{ needs.setup.outputs.is_prerelease }}" = "true" ]; then
-            pnpm dlx vsce publish --packagePath *.vsix --pre-release
+            pnpm dlx @vscode/vsce publish --packagePath *.vsix --pre-release
           else
-            pnpm dlx vsce publish --packagePath *.vsix
+            pnpm dlx @vscode/vsce publish --packagePath *.vsix
           fi
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
@@ -192,15 +192,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24.x'
+          node-version: '22.x'
 
       - name: Publish to Open VSX Registry
         run: |
-          if [ "${{ needs.setup.outputs.is_prerelease }}" = "true" ]; then
-            pnpm dlx ovsx publish *.vsix --pre-release
-          else
-            pnpm dlx ovsx publish *.vsix
-          fi
+          pnpm dlx ovsx publish *.vsix
         env:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,15 @@ jobs:
           node-version: '22.x'
           cache: pnpm
 
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-node22.x-${{ hashFiles('pnpm-lock.yaml') }}
+
       - name: Install Dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Prepare Extension for Publishing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,17 +37,17 @@ jobs:
     needs: [setup]
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.setup.outputs.tag }}
 
       - name: Install PNPM
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
-          version: 10
+          standalone: true
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22.x'
           cache: pnpm
@@ -62,7 +62,7 @@ jobs:
         run: pnpm run package
 
       - name: Upload VSIX Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: vsix-package
           path: '*.vsix'
@@ -73,7 +73,7 @@ jobs:
     needs: [release-build]
     steps:
       - name: Download VSIX Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: vsix-package
 
@@ -150,17 +150,17 @@ jobs:
     needs: [setup, verifier]
     steps:
       - name: Download VSIX Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: vsix-package
 
       - name: Install PNPM
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
-          version: 10
+          standalone: true
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22.x'
 
@@ -180,17 +180,17 @@ jobs:
     needs: [setup, verifier]
     steps:
       - name: Download VSIX Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: vsix-package
 
       - name: Install PNPM
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
-          version: 10
+          standalone: true
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22.x'
 
@@ -206,7 +206,7 @@ jobs:
     needs: [setup, publish-vscode, publish-openvsx]
     steps:
       - name: Download VSIX Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: vsix-package
 

--- a/.github/workflows/security-daily.yml
+++ b/.github/workflows/security-daily.yml
@@ -38,7 +38,15 @@ jobs:
             pnpm-lock.yaml
             package.json
 
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-node22.x-${{ hashFiles('pnpm-lock.yaml') }}
+
       - name: Install Dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Run Security Audit

--- a/.github/workflows/security-pr.yml
+++ b/.github/workflows/security-pr.yml
@@ -18,17 +18,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 
       - name: Install PNPM
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
+        uses: pnpm/action-setup@v6
         with:
           standalone: true
 
       - name: Setup Node.js
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
+        uses: actions/setup-node@v5
         with:
           node-version: '22.x'
 
@@ -44,7 +44,7 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 

--- a/.github/workflows/security-pr.yml
+++ b/.github/workflows/security-pr.yml
@@ -31,8 +31,17 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: '22.x'
+          cache: pnpm
+
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-node22.x-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install Dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Run pnpm Audit


### PR DESCRIPTION
Fixes release workflow issues on Node 24 by downgrading Node.js version to 22.x, using @vscode/vsce package name instead of deprecated vsce, and aligning other workflows to the latest configs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
- Updated CI/CD pipeline and release workflow actions to use current stable tooling versions for improved infrastructure stability and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Vijay431/additional-context-menus/pull/265?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->