### PR TITLE
fix(ci): add checkout step to release publish jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,6 +157,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [setup, verifier]
     steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.setup.outputs.tag }}
+
       - name: Download VSIX Artifact
         uses: actions/download-artifact@v7
         with:
@@ -187,6 +192,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [setup, verifier]
     steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.setup.outputs.tag }}
+
       - name: Download VSIX Artifact
         uses: actions/download-artifact@v7
         with:


### PR DESCRIPTION
Fixes the pnpm version error in the publish jobs of the release workflow by checking out the repository so that the package manager configuration in package.json is accessible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow to ensure proper tag checkout during publishing to VS Code Marketplace and Open VSX Registry, enhancing release integrity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Vijay431/additional-context-menus/pull/268?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->