### PR TITLE
Fix vsce package failure by pinning linkify-it to ^5.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the "Additional Context Menus" extension will be document
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Pin `linkify-it` override to `^5.0.2` to fix `vsce package` failing with `linkify_it.default is not a constructor`; linkify-it 6.0.0 dropped the CJS default export required by markdown-it 14.x. ([#327](https://github.com/Vijay431/additional-context-menus/pull/327))
+
 ## [2.1.3]
 
 ### Changed

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ overrides:
   shell-quote: '>=1.8.4'
   form-data: '>=4.0.6'
   undici: '>=7.28.0'
-  linkify-it: '>=5.0.1'
+  linkify-it: ^5.0.2
   vite: '>=6.4.3'
   markdown-it: '>=14.1.2'
   js-yaml: '>=4.1.2'
@@ -2330,8 +2330,8 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  linkify-it@6.0.0:
-    resolution: {integrity: sha512-YXaVuD1L9iL52IsWy5WsfHbzJjjDL5VzbW7ARliFbB+oHxHXb+fh2qjYl34PGhyy06x3LCvuAuvWdaSFte0P1w==}
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
 
   lint-staged@17.1.0:
     resolution: {integrity: sha512-d7UQRu/9ZPgfu4+hu/k0wny5GEaIxo+2jb2LJqQDkE7cHRTm1HGqNUDq5UOwsGPpjpaNAFmgAsYo3TR+i9cSJw==}
@@ -5846,7 +5846,7 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  linkify-it@6.0.0:
+  linkify-it@5.0.2:
     dependencies:
       uc.micro: 2.1.0
 
@@ -5920,7 +5920,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
-      linkify-it: 6.0.0
+      linkify-it: 5.0.2
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,7 +18,7 @@ overrides:
   shell-quote: '>=1.8.4'
   form-data: '>=4.0.6'
   undici: '>=7.28.0'
-  linkify-it: '>=5.0.1'
+  linkify-it: '^5.0.2'
   vite: '>=6.4.3'
   markdown-it: '>=14.1.2'
   js-yaml: '>=4.1.2'


### PR DESCRIPTION
## Summary

Pins the `linkify-it` dependency override to `^5.0.2` to resolve a `vsce package` failure caused by linkify-it 6.0.0 dropping the CommonJS default export required by markdown-it 14.x.

The error `linkify_it.default is not a constructor` occurs during packaging because markdown-it 14.x expects the CJS default export that was removed in linkify-it 6.0.0. Constraining to `^5.0.2` ensures a compatible version is used.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] CI/build tooling
- [ ] Maintenance

## Verification

- [x] `pnpm run lint`
- [x] `pnpm run build`
- [x] `pnpm run package` (resolves the vsce packaging failure)

## Checklist

- [x] I updated docs or changelog entries when user-facing behavior changed.
- [x] I avoided generated output in `dist/`, `out-test/`, and compiled `.js`/`.map` files.
- [x] I kept the PR focused and within the repository commit-size guidance.

## Related

Closes #327

https://claude.ai/code/session_01RYPo2qcu1T3hoFcHc51ST1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed package creation failures by updating the `linkify-it` dependency version.
  * Added a changelog entry documenting the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->