### PR TITLE
fix(deps): remove linkify-it/markdown-it overrides breaking vsce package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Security audit remediation**: Added pnpm overrides for vulnerable dev-only transitive dependencies (`shell-quote`, `tmp`, `form-data`, `undici`, `linkify-it`, `markdown-it`, `js-yaml`, `vite`) and regenerated `pnpm-lock.yaml` so `pnpm audit` reports zero vulnerabilities. `esbuild` is bumped directly in `package.json` since it's a direct devDependency.
+- **Security audit remediation**: Added pnpm overrides for vulnerable dev-only transitive dependencies (`shell-quote`, `tmp`, `form-data`, `undici`, `js-yaml`, `vite`) and regenerated `pnpm-lock.yaml` so `pnpm audit` reports zero vulnerabilities. `esbuild` is bumped directly in `package.json` since it's a direct devDependency.
 
 ### Fixed
 
 - Removed a redundant type assertion in `ProjectDetectionService.getFrameworks()`.
+- **vsce packaging**: Removed `linkify-it` and `markdown-it` pnpm overrides that forced ESM-only `linkify-it@6` into `vsce`'s CommonJS dependency tree, causing `linkify_it.default is not a constructor` at `vsce package` time. These packages are dev-only transitive dependencies of `@vscode/vsce` and are not included in the published VSIX bundle.
 
 ## [2.1.2]
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,9 +16,7 @@ overrides:
   shell-quote: '>=1.8.4'
   form-data: '>=4.0.6'
   undici: '>=7.28.0'
-  linkify-it: '>=5.0.1'
   vite: '>=6.4.3'
-  markdown-it: '>=14.1.2'
   js-yaml: '>=4.1.2'
 
 importers:
@@ -2330,8 +2328,8 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  linkify-it@6.0.0:
-    resolution: {integrity: sha512-YXaVuD1L9iL52IsWy5WsfHbzJjjDL5VzbW7ARliFbB+oHxHXb+fh2qjYl34PGhyy06x3LCvuAuvWdaSFte0P1w==}
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
 
   lint-staged@17.1.0:
     resolution: {integrity: sha512-d7UQRu/9ZPgfu4+hu/k0wny5GEaIxo+2jb2LJqQDkE7cHRTm1HGqNUDq5UOwsGPpjpaNAFmgAsYo3TR+i9cSJw==}
@@ -5846,7 +5844,7 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  linkify-it@6.0.0:
+  linkify-it@5.0.2:
     dependencies:
       uc.micro: 2.1.0
 
@@ -5920,7 +5918,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
-      linkify-it: 6.0.0
+      linkify-it: 5.0.2
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,7 +18,5 @@ overrides:
   shell-quote: '>=1.8.4'
   form-data: '>=4.0.6'
   undici: '>=7.28.0'
-  linkify-it: '>=5.0.1'
   vite: '>=6.4.3'
-  markdown-it: '>=14.1.2'
   js-yaml: '>=4.1.2'


### PR DESCRIPTION
Removes the `linkify-it: '>=5.0.1'` and `markdown-it: '>=14.1.2'` pnpm overrides from pnpm-workspace.yaml. The `linkify-it` override forced `linkify-it@6.0.0` (ESM-only) into `@vscode/vsce`'s CommonJS dependency tree, causing `linkify_it.default is not a constructor` at package time.

Without the override, pnpm resolves `linkify-it@5.0.2` (CJS-compatible, `main: build/index.cjs.js`) which satisfies `markdown-it@14.x` and does not break vsce. Both packages are dev-only transitive deps of vsce and are not included in the published VSIX bundle.


Claude-Session: https://claude.ai/code/session_01GnUjYR8rFzNN43piid4Nn4

## Summary

Describe the change and why it is needed.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] CI/build tooling
- [ ] Maintenance

## Verification

- [ ] `pnpm run lint`
- [ ] `pnpm run build`
- [ ] `pnpm run test:unit`
- [ ] `pnpm run test:unit:coverage`
- [ ] `pnpm run test:integration`
- [ ] Manual VS Code Extension Development Host check

## Screenshots or recordings

Add screenshots or recordings for visible VS Code UI changes.

## Checklist

- [ ] I updated docs or changelog entries when user-facing behavior changed.
- [ ] I avoided generated output in `dist/`, `out-test/`, and compiled `.js`/`.map` files.
- [ ] I kept the PR focused and within the repository commit-size guidance.
