### PR TITLE
ci: add packaging dry-run to build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,3 +178,6 @@ jobs:
         run: pnpm run build
         env:
           VSCODE_VERSION: stable
+
+      - name: Package Extension (dry-run)
+        run: pnpm run package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **CI packaging dry-run**: `build` job now runs `pnpm run package` (`vsce package`) after the build step, across the Node 22/24/26 matrix — validates the VSIX packaging pipeline on every PR/main run instead of only at release time. No upload/publish occurs.
+
 ### Fixed
 - Daily security audit workflow now manages a single tracking issue instead of creating duplicate issues each day; resolves all 41 stale bot-generated security alert issues
 - Updated CLAUDE.md to correctly document that `codeAnalysisService` uses `@babel/parser` (not TypeScript Compiler API)


### PR DESCRIPTION
## Summary
- `build` job now runs `pnpm run package` (`vsce package`) after the build step, across the Node 22/24/26 matrix — validates the VSIX packaging pipeline on every PR/main run instead of only at release time.
- No upload/publish occurs; `vsce package` produces a local `.vsix` only (inherent dry-run).

## Test plan
- [x] `pnpm run package` verified locally against updated `main` (2.1.3) — produces `.vsix`, exits 0
- [x] CI `Build` matrix jobs (22.x/24.x/26.x) run new `Package Extension (dry-run)` step green