### PR TITLE
fix(security): patch js-yaml and brace-expansion advisories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,15 @@ All notable changes to the "Additional Context Menus" extension will be document
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.1.4] - 2026-07-26
 
 ### Changed
 
 - **CI packaging dry-run**: `build` job now runs `pnpm run package` (`vsce package`) after the build step, across the Node 22/24/26 matrix — validates the VSIX packaging pipeline on every PR/main run instead of only at release time. No upload/publish occurs.
 
 ### Fixed
+
+- **Security audit remediation**: Bumped pnpm overrides for `js-yaml` (`>=4.1.2` → `>=5.2.2`) and `brace-expansion` (`>=5.0.6` → `>=5.0.8`) to close two high-severity dev-only transitive dependency advisories — `js-yaml` exponential-time parsing DoS ([GHSA-pm4m-ph32-ghv5](https://github.com/advisories/GHSA-pm4m-ph32-ghv5)) and `brace-expansion` unbounded expansion DoS ([GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg)). Both packages are dev-only transitive dependencies (commitlint, vsce/secretlint, eslint/typescript-eslint tooling) and are not part of the published VSIX bundle. `pnpm audit` now reports zero vulnerabilities.
 - Daily security audit workflow now manages a single tracking issue instead of creating duplicate issues each day; resolves all 41 stale bot-generated security alert issues
 - Updated CLAUDE.md to correctly document that `codeAnalysisService` uses `@babel/parser` (not TypeScript Compiler API)
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "additional-context-menus",
   "displayName": "Additional Context Menus",
   "description": "Supercharge your development with intelligent right-click menus. Extract functions, move code blocks, and refactor your TypeScript and JavaScript codebase in seconds. Features AST-based detection, smart imports, and an optimized bundle.",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "license": "MIT",
   "packageManager": "pnpm@11.2.2",
   "publisher": "VijayGangatharan",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   fast-uri: '>=3.1.2'
   serialize-javascript: '>=7.0.5'
   postcss: '>=8.5.10'
-  brace-expansion: '>=5.0.6'
+  brace-expansion: '>=5.0.8'
   diff: '>=8.0.3'
   tmp: '>=0.2.7'
   '@azure/msal-node>uuid': 11.1.1
@@ -17,7 +17,7 @@ overrides:
   form-data: '>=4.0.6'
   undici: '>=7.28.0'
   vite: '>=6.4.3'
-  js-yaml: '>=4.1.2'
+  js-yaml: '>=5.2.2'
 
 importers:
 
@@ -1157,9 +1157,9 @@ packages:
   boundary@2.0.0:
     resolution: {integrity: sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2183,8 +2183,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@5.2.1:
-    resolution: {integrity: sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==}
+  js-yaml@5.2.2:
+    resolution: {integrity: sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -4130,7 +4130,7 @@ snapshots:
       '@textlint/types': 15.7.1
       chalk: 4.1.2
       debug: 4.4.3(supports-color@8.1.1)
-      js-yaml: 5.2.1
+      js-yaml: 5.2.2
       lodash: 4.18.1
       pluralize: 2.0.0
       string-width: 4.2.3
@@ -4575,7 +4575,7 @@ snapshots:
 
   boundary@2.0.0: {}
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -4748,7 +4748,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 5.2.1
+      js-yaml: 5.2.2
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -5707,7 +5707,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@5.2.1:
+  js-yaml@5.2.2:
     dependencies:
       argparse: 2.0.1
 
@@ -5951,15 +5951,15 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimist@1.2.8: {}
 
@@ -5979,7 +5979,7 @@ snapshots:
       glob: 10.5.0
       he: 1.2.0
       is-path-inside: 3.0.3
-      js-yaml: 5.2.1
+      js-yaml: 5.2.2
       log-symbols: 4.1.0
       minimatch: 9.0.9
       ms: 2.1.3
@@ -6290,7 +6290,7 @@ snapshots:
   rc-config-loader@4.1.4:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
-      js-yaml: 5.2.1
+      js-yaml: 5.2.2
       json5: 2.2.3
       require-from-string: 2.0.2
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,7 @@ overrides:
   fast-uri: '>=3.1.2'
   serialize-javascript: '>=7.0.5'
   postcss: '>=8.5.10'
-  brace-expansion: '>=5.0.6'
+  brace-expansion: '>=5.0.8'
   diff: '>=8.0.3'
   tmp: '>=0.2.7'
   '@azure/msal-node>uuid': 11.1.1
@@ -19,4 +19,4 @@ overrides:
   form-data: '>=4.0.6'
   undici: '>=7.28.0'
   vite: '>=6.4.3'
-  js-yaml: '>=4.1.2'
+  js-yaml: '>=5.2.2'


### PR DESCRIPTION
## Summary

Scheduled security audit found 2 high-severity advisories via `pnpm audit`. Both are dev-only transitive dependencies (not bundled in the published VSIX), fixed by tightening `pnpm-workspace.yaml` overrides:

- **`js-yaml`**: override raised from `>=4.1.2` to `>=5.2.2`. The old override resolved to the vulnerable `5.2.1`. Fixes exponential-time parsing DoS in flow collections ([GHSA-pm4m-ph32-ghv5](https://github.com/advisories/GHSA-pm4m-ph32-ghv5)). Pulled in transitively via `@commitlint/cli` → `cosmiconfig`, and `@vscode/vsce` → `@secretlint/node` → `rc-config-loader`.
- **`brace-expansion`**: override raised from `>=5.0.6` to `>=5.0.8`. The old override resolved to the vulnerable `5.0.7`. Fixes DoS via unbounded expansion length causing OOM crash ([GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg)). Pulled in transitively via `eslint`/`@typescript-eslint/*` → `minimatch`.

`pnpm audit` now reports **0 vulnerabilities** (previously 2 high). `pnpm-lock.yaml` regenerated accordingly.

Also bumped `package.json` version `2.1.3` → `2.1.4` (patch) and folded the changelog's `Unreleased` entries into a new `[2.1.4]` release section per this project's changelog convention (no `Unreleased` section left in place).

## Type of change

- [x] Bug fix (security)
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] CI/build tooling
- [ ] Maintenance

## Verification

- [x] `pnpm audit` — 0 vulnerabilities (was 2 high)
- [x] `pnpm run lint` — 0 errors (2 pre-existing warnings in `codeAnalysisService.ts`, unrelated to this change)
- [x] `pnpm run build` — succeeds, bundle sizes unchanged
- [x] `pnpm run test:unit` — 124/124 passing
- [ ] `pnpm run test:integration` — **could not run in this sandboxed environment**: the outbound proxy returns a 403 policy denial for `update.code.visualstudio.com`, which `@vscode/test-electron` needs to download the test VS Code binary. This is an environment network-policy limitation, not a code issue — the change only touches devDependency version resolution in `pnpm-workspace.yaml`/`pnpm-lock.yaml` and does not affect any runtime/extension code the integration suite exercises. Should run cleanly in CI, which has unrestricted network access.
- [ ] Manual VS Code Extension Development Host check — not applicable, no runtime code changed

## Screenshots or recordings

N/A — no UI changes.

## Checklist

- [x] I updated docs or changelog entries when user-facing behavior changed. (`CHANGELOG.md` updated; no user-facing behavior changed since only dev tooling deps are affected)
- [x] I avoided generated output in `dist/`, `out-test/`, and compiled `.js`/`.map` files.
- [x] I kept the PR focused and within the repository commit-size guidance. (1 commit, 4 files, 22 insertions / 20 deletions)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AjukFbmJvqHAKkxVAB69pu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the extension to version 2.1.4.

* **Bug Fixes**
  * Updated dependency versions to address security audit findings.
  * Confirmed the project reports no known vulnerabilities through its security audit.

* **Chores**
  * Added a package dry-run check to the build process across supported Node.js versions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->