### PR TITLE
fix(security): remediate npm audit findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Daily security audit workflow now manages a single tracking issue instead of creating duplicate issues each day; resolves all 41 stale bot-generated security alert issues
 - Updated CLAUDE.md to correctly document that `codeAnalysisService` uses `@babel/parser` (not TypeScript Compiler API)
+- **Security audit remediation**: Tightened pnpm overrides for `js-yaml` (`>=4.1.2` → `>=5.2.2`) and `brace-expansion` (`>=5.0.6` → `>=5.0.8`) — the prior ranges were resolving to vulnerable versions (`js-yaml@5.2.1`, `brace-expansion@5.0.7`) because they only set a floor without excluding the vulnerable window. `pnpm audit --audit-level=low` now reports zero vulnerabilities.
 
 ## [2.1.3] - 2026-07-20
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   fast-uri: '>=3.1.2'
   serialize-javascript: '>=7.0.5'
   postcss: '>=8.5.10'
-  brace-expansion: '>=5.0.6'
+  brace-expansion: '>=5.0.8'
   diff: '>=8.0.3'
   tmp: '>=0.2.7'
   '@azure/msal-node>uuid': 11.1.1
@@ -17,7 +17,7 @@ overrides:
   form-data: '>=4.0.6'
   undici: '>=7.28.0'
   vite: '>=6.4.3'
-  js-yaml: '>=4.1.2'
+  js-yaml: '>=5.2.2'
 
 importers:
 
@@ -1157,9 +1157,9 @@ packages:
   boundary@2.0.0:
     resolution: {integrity: sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2183,8 +2183,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@5.2.1:
-    resolution: {integrity: sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==}
+  js-yaml@5.2.2:
+    resolution: {integrity: sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -4130,7 +4130,7 @@ snapshots:
       '@textlint/types': 15.7.1
       chalk: 4.1.2
       debug: 4.4.3(supports-color@8.1.1)
-      js-yaml: 5.2.1
+      js-yaml: 5.2.2
       lodash: 4.18.1
       pluralize: 2.0.0
       string-width: 4.2.3
@@ -4575,7 +4575,7 @@ snapshots:
 
   boundary@2.0.0: {}
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -4748,7 +4748,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 5.2.1
+      js-yaml: 5.2.2
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -5707,7 +5707,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@5.2.1:
+  js-yaml@5.2.2:
     dependencies:
       argparse: 2.0.1
 
@@ -5951,15 +5951,15 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.9
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 
@@ -5979,7 +5979,7 @@ snapshots:
       glob: 10.5.0
       he: 1.2.0
       is-path-inside: 3.0.3
-      js-yaml: 5.2.1
+      js-yaml: 5.2.2
       log-symbols: 4.1.0
       minimatch: 9.0.9
       ms: 2.1.3
@@ -6290,7 +6290,7 @@ snapshots:
   rc-config-loader@4.1.4:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
-      js-yaml: 5.2.1
+      js-yaml: 5.2.2
       json5: 2.2.3
       require-from-string: 2.0.2
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,7 @@ overrides:
   fast-uri: '>=3.1.2'
   serialize-javascript: '>=7.0.5'
   postcss: '>=8.5.10'
-  brace-expansion: '>=5.0.6'
+  brace-expansion: '>=5.0.8'
   diff: '>=8.0.3'
   tmp: '>=0.2.7'
   '@azure/msal-node>uuid': 11.1.1
@@ -19,4 +19,4 @@ overrides:
   form-data: '>=4.0.6'
   undici: '>=7.28.0'
   vite: '>=6.4.3'
-  js-yaml: '>=4.1.2'
+  js-yaml: '>=5.2.2'


### PR DESCRIPTION
## Summary

Daily automated `pnpm audit` run found 2 high-severity vulnerabilities. Both packages already had pnpm overrides in `pnpm-workspace.yaml`, but the ranges were floor-only (`>=X`) and resolved to versions still inside the vulnerable window. Tightened both overrides to the actual patched minimum.

| CVE / Advisory | Package | Old constraint | Resolved (vulnerable) | New constraint | Resolves to |
| --- | --- | --- | --- | --- | --- |
| [GHSA-pm4m-ph32-ghv5](https://github.com/advisories/GHSA-pm4m-ph32-ghv5) — js-yaml exponential parsing DoS | `js-yaml` | `>=4.1.2` | `5.2.1` (vulnerable range `>=5.0.0 <=5.2.1`) | `>=5.2.2` | `5.2.2` |
| [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) — brace-expansion unbounded expansion DoS | `brace-expansion` | `>=5.0.6` | `5.0.7` (vulnerable range `>=4.0.0 <5.0.8`) | `>=5.0.8` | `5.0.8` |

Both are dev-only transitive dependencies (commitlint/cosmiconfig/secretlint chain for js-yaml; eslint/minimatch chain for brace-expansion) — not part of the published VSIX bundle.

**Version verification** (per audit runbook): confirmed via `npm view <pkg> versions --json` that `js-yaml@5.2.2` and `brace-expansion@5.0.8` exist on the registry and are not deprecated, before applying the override.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] CI/build tooling
- [ ] Maintenance

## Verification

- [x] `pnpm run lint` — 0 errors, 2 pre-existing warnings in `codeAnalysisService.ts` (unrelated to this change, no source files touched)
- [x] `pnpm run build` — succeeds, main bundle 469.23 KB
- [x] `pnpm run test:unit` — 124/124 tests passed across 13 files
- [ ] `pnpm run test:unit:coverage` — not run (not required by audit runbook)
- [ ] `pnpm run test:integration` — skipped, no display/xvfb available in this environment
- [ ] Manual VS Code Extension Development Host check — not applicable, no runtime code changed

**Final `pnpm audit --audit-level=low`:**
```
No known vulnerabilities found
```

**`pnpm install` after the override change:** no peer-dependency warnings, no ERESOLVE conflicts.

## Screenshots or recordings

N/A — no UI changes.

## Checklist

- [x] I updated docs or changelog entries when user-facing behavior changed. (`CHANGELOG.md` Unreleased → Fixed)
- [x] I avoided generated output in `dist/`, `out-test/`, and compiled `.js`/`.map` files.
- [x] I kept the PR focused and within the repository commit-size guidance. (3 files changed: `pnpm-workspace.yaml`, `pnpm-lock.yaml`, `CHANGELOG.md`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01K9cYvFnXURFhoU7yCfYp3o)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated dependency version requirements to prevent vulnerable versions of `brace-expansion` and `js-yaml`.
  * Dependency auditing now reports no low-severity vulnerabilities.

* **Documentation**
  * Added an unreleased changelog entry documenting the security updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->