### PR TITLE
fix(security): remediate npm audit findings

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  fast-uri: '>=3.1.2'
+  fast-uri: '>=4.1.2'
   serialize-javascript: '>=7.0.5'
-  postcss: '>=8.5.10'
+  postcss: '>=8.5.23'
   brace-expansion: '>=5.0.8'
   diff: '>=8.0.3'
   tmp: '>=0.2.7'
@@ -15,7 +15,7 @@ overrides:
   typed-rest-client>qs: 6.15.2
   shell-quote: '>=1.8.4'
   form-data: '>=4.0.6'
-  undici: '>=7.28.0'
+  undici: '>=8.9.0'
   vite: '>=6.4.3'
   js-yaml: '>=5.2.2'
 
@@ -1712,8 +1712,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@4.1.1:
-    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
+  fast-uri@4.1.2:
+    resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -2696,8 +2696,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.19:
-    resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
   prebuild-install@7.1.3:
@@ -3227,8 +3227,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@8.7.0:
-    resolution: {integrity: sha512-N7iQtfyLhIMOFgQubvmLV26svHpO0bqKnAiWotTQCVKCmWrcGbBotPuW1x+xwYZ2VHdSTVUfPQQnlEt1/LouTQ==}
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
     engines: {node: '>=22.19.0'}
 
   unicorn-magic@0.1.0:
@@ -4437,7 +4437,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.1
+      fast-uri: 4.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -4653,7 +4653,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 8.7.0
+      undici: 8.10.0
       whatwg-mimetype: 4.0.0
 
   chokidar@4.0.3:
@@ -5236,7 +5236,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@4.1.1: {}
+  fast-uri@4.1.2: {}
 
   fastq@1.20.1:
     dependencies:
@@ -6236,7 +6236,7 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.19:
+  postcss@8.5.25:
     dependencies:
       nanoid: 3.3.16
       picocolors: 1.1.1
@@ -6853,7 +6853,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@8.7.0: {}
+  undici@8.10.0: {}
 
   unicorn-magic@0.1.0: {}
 
@@ -6880,7 +6880,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
-      postcss: 8.5.19
+      postcss: 8.5.25
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,9 +7,9 @@ minimumReleaseAgeExclude:
   - tmp@0.2.7
 
 overrides:
-  fast-uri: '>=3.1.2'
+  fast-uri: '>=4.1.2'
   serialize-javascript: '>=7.0.5'
-  postcss: '>=8.5.10'
+  postcss: '>=8.5.23'
   brace-expansion: '>=5.0.8'
   diff: '>=8.0.3'
   tmp: '>=0.2.7'
@@ -17,6 +17,6 @@ overrides:
   'typed-rest-client>qs': 6.15.2
   shell-quote: '>=1.8.4'
   form-data: '>=4.0.6'
-  undici: '>=7.28.0'
+  undici: '>=8.9.0'
   vite: '>=6.4.3'
   js-yaml: '>=5.2.2'


### PR DESCRIPTION
## Summary

Daily `pnpm audit` found 7 vulnerabilities, all transitive to dev-only tooling (vitest/vite, `@vscode/vsce`, `ovsx`, `@commitlint/cli`) — none are part of the shipped extension bundle. Fixed by tightening the existing `overrides` floors in `pnpm-workspace.yaml` (no new override keys, no direct `package.json` dependency changes needed since none of the vulnerable packages are direct deps).

| CVE / Advisory | Package | Severity | Old override | New override | Vulnerable range | Patched range |
| --- | --- | --- | --- | --- | --- | --- |
| [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) | `fast-uri` | high | `>=3.1.2` | `>=4.1.2` | `>=4.0.0 <4.1.2` | `>=4.1.2` |
| [GHSA-fxqj-rqcc-2cmp](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp) | `postcss` | moderate | `>=8.5.10` | `>=8.5.23` | `<=8.5.22` | `>=8.5.23` |
| [GHSA-4cwx-7wf7-3272](https://github.com/advisories/GHSA-4cwx-7wf7-3272) | `undici` | high | `>=7.28.0` | `>=8.9.0` | `>=8.0.0 <8.9.0` | `>=8.9.0` |
| [GHSA-8xcm-r25x-g524](https://github.com/advisories/GHSA-8xcm-r25x-g524) | `undici` | moderate | `>=7.28.0` | `>=8.9.0` | `>=8.0.0 <8.9.0` | `>=8.9.0` |
| [GHSA-m8rv-5g2x-5cg5](https://github.com/advisories/GHSA-m8rv-5g2x-5cg5) | `undici` | moderate | `>=7.28.0` | `>=8.9.0` | `>=8.0.0 <8.9.0` | `>=8.9.0` |
| [GHSA-jr45-8vmc-qm54](https://github.com/advisories/GHSA-jr45-8vmc-qm54) | `undici` | moderate | `>=7.28.0` | `>=8.9.0` | `>=8.0.0 <8.9.0` | `>=8.9.0` |
| [GHSA-v3r7-h72x-cjcm](https://github.com/advisories/GHSA-v3r7-h72x-cjcm) | `undici` | moderate | `>=7.28.0` | `>=8.9.0` | `>=8.0.0 <8.9.0` | `>=8.9.0` |

Dependency paths (dev-only):
- `fast-uri`: via `@commitlint/cli` → `ajv` chain, and `@vscode/vsce` → `@secretlint/node` → `ajv` chain
- `postcss`: via `vitest`/`@vitest/coverage-v8` → `vite`
- `undici`: via `@vscode/vsce` and `ovsx` → `cheerio`

### Version verification (`npm view`)

- `npm view fast-uri versions --json` → confirms `4.1.2` exists on the registry; `npm view fast-uri@4.1.2 version deprecated` → not deprecated.
- `npm view postcss versions --json` → confirms `8.5.25` (latest, satisfies `>=8.5.23`) exists; `npm view postcss@8.5.25 version deprecated` → not deprecated.
- `npm view undici versions --json` → confirms `8.10.0` (latest, satisfies `>=8.9.0`) exists; `npm view undici@8.10.0 version deprecated` → not deprecated.

No direct dependency in `package.json` is affected, so only `pnpm-workspace.yaml` overrides changed (plus the resulting `pnpm-lock.yaml` update).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] CI/build tooling
- [x] Maintenance

## Verification

- [x] `pnpm run lint` — 0 errors, 2 pre-existing warnings in `src/services/codeAnalysisService.ts` unrelated to this change
- [x] `pnpm run build` — succeeds, main bundle 469.23 KB (within the 100KB *core* target budget check — no regression)
- [x] `pnpm run test:unit` — 124/124 tests passed across 13 files
- [ ] `pnpm run test:unit:coverage` — not run (not required by this audit workflow)
- [ ] `pnpm run test:integration` — skipped, no display/xvfb available in this environment
- [ ] Manual VS Code Extension Development Host check — not applicable, no runtime code changed

### Final `pnpm audit --audit-level=low`

```
No known vulnerabilities found
```

### `pnpm run test:unit` output

```
 Test Files  13 passed (13)
      Tests  124 passed (124)
```

## Screenshots or recordings

N/A — dependency/override change only, no UI impact.

## Checklist

- [x] I updated docs or changelog entries when user-facing behavior changed. (N/A — no user-facing behavior changed; CLAUDE.md/README not touched since this is a dependency-only security fix)
- [x] I avoided generated output in `dist/`, `out-test/`, and compiled `.js`/`.map` files.
- [x] I kept the PR focused and within the repository commit-size guidance. (1 commit, 2 files, 36 changed lines)


---
_Generated by [Claude Code](https://claude.ai/code/session_01A5m6ApjhaKuegRef3918e4)_