### PR TITLE
fix(security): remediate npm audit findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Daily security audit workflow now manages a single tracking issue instead of creating duplicate issues each day; resolves all 41 stale bot-generated security alert issues
 - Updated CLAUDE.md to correctly document that `codeAnalysisService` uses `@babel/parser` (not TypeScript Compiler API)
 - **Security audit remediation**: Tightened pnpm overrides for `js-yaml` (`>=4.1.2` → `>=5.2.2`) and `brace-expansion` (`>=5.0.6` → `>=5.0.8`) — the prior ranges were resolving to vulnerable versions (`js-yaml@5.2.1`, `brace-expansion@5.0.7`) because they only set a floor without excluding the vulnerable window. `pnpm audit --audit-level=low` now reports zero vulnerabilities.
+- **Security audit remediation**: Tightened pnpm overrides for `undici` (`>=7.28.0` → `>=8.9.0`), `fast-uri` (`>=3.1.2` → `>=4.1.2`), and `postcss` (`>=8.5.10` → `>=8.5.23`) — the prior ranges were resolving to vulnerable versions (`undici@8.7.0`, `fast-uri@4.1.1`, `postcss@8.5.19`) because they only set a floor without excluding the vulnerable window. `pnpm audit --audit-level=low` now reports zero vulnerabilities.
 
 ## [2.1.3] - 2026-07-20
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  fast-uri: '>=3.1.2'
+  fast-uri: '>=4.1.2'
   serialize-javascript: '>=7.0.5'
-  postcss: '>=8.5.10'
+  postcss: '>=8.5.23'
   brace-expansion: '>=5.0.8'
   diff: '>=8.0.3'
   tmp: '>=0.2.7'
@@ -15,7 +15,7 @@ overrides:
   typed-rest-client>qs: 6.15.2
   shell-quote: '>=1.8.4'
   form-data: '>=4.0.6'
-  undici: '>=7.28.0'
+  undici: '>=8.9.0'
   vite: '>=6.4.3'
   js-yaml: '>=5.2.2'
 
@@ -1712,8 +1712,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@4.1.1:
-    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
+  fast-uri@4.1.2:
+    resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -2696,8 +2696,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.19:
-    resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
   prebuild-install@7.1.3:
@@ -3227,8 +3227,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@8.7.0:
-    resolution: {integrity: sha512-N7iQtfyLhIMOFgQubvmLV26svHpO0bqKnAiWotTQCVKCmWrcGbBotPuW1x+xwYZ2VHdSTVUfPQQnlEt1/LouTQ==}
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
     engines: {node: '>=22.19.0'}
 
   unicorn-magic@0.1.0:
@@ -4437,7 +4437,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.1
+      fast-uri: 4.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -4653,7 +4653,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 8.7.0
+      undici: 8.10.0
       whatwg-mimetype: 4.0.0
 
   chokidar@4.0.3:
@@ -5236,7 +5236,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@4.1.1: {}
+  fast-uri@4.1.2: {}
 
   fastq@1.20.1:
     dependencies:
@@ -6236,7 +6236,7 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.19:
+  postcss@8.5.25:
     dependencies:
       nanoid: 3.3.16
       picocolors: 1.1.1
@@ -6853,7 +6853,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@8.7.0: {}
+  undici@8.10.0: {}
 
   unicorn-magic@0.1.0: {}
 
@@ -6880,7 +6880,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
-      postcss: 8.5.19
+      postcss: 8.5.25
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,9 +7,9 @@ minimumReleaseAgeExclude:
   - tmp@0.2.7
 
 overrides:
-  fast-uri: '>=3.1.2'
+  fast-uri: '>=4.1.2'
   serialize-javascript: '>=7.0.5'
-  postcss: '>=8.5.10'
+  postcss: '>=8.5.23'
   brace-expansion: '>=5.0.8'
   diff: '>=8.0.3'
   tmp: '>=0.2.7'
@@ -17,6 +17,6 @@ overrides:
   'typed-rest-client>qs': 6.15.2
   shell-quote: '>=1.8.4'
   form-data: '>=4.0.6'
-  undici: '>=7.28.0'
+  undici: '>=8.9.0'
   vite: '>=6.4.3'
   js-yaml: '>=5.2.2'


### PR DESCRIPTION
## Summary

Daily `pnpm audit` found 7 advisories (2 high, 5 moderate), all in dev-only transitive dependencies. Root cause: existing `pnpm-workspace.yaml` overrides for `undici`, `fast-uri`, and `postcss` only set a version floor without excluding the known-vulnerable window, so pnpm kept resolving to vulnerable patch versions. Tightened each override's lower bound to the first patched version.

| Package | Advisory | Severity | Path | Old → New |
|---|---|---|---|---|
| `undici` | [GHSA-4cwx-7wf7-3272](https://github.com/advisories/GHSA-4cwx-7wf7-3272) — cross-user info disclosure + parse-time crash via degenerate private cache directives | High | `@vscode/vsce` / `ovsx` → `cheerio` → `undici` | `8.7.0` → `8.10.0` |
| `undici` | [GHSA-8xcm-r25x-g524](https://github.com/advisories/GHSA-8xcm-r25x-g524) — response desync via retry interceptor | Moderate | same path | `8.7.0` → `8.10.0` |
| `undici` | [GHSA-m8rv-5g2x-5cg5](https://github.com/advisories/GHSA-m8rv-5g2x-5cg5) — CRLF injection via blob-like body `type` | Moderate | same path | `8.7.0` → `8.10.0` |
| `undici` | [GHSA-jr45-8vmc-qm54](https://github.com/advisories/GHSA-jr45-8vmc-qm54) — cross-user info disclosure via whitespace in Cache-Control | Moderate | same path | `8.7.0` → `8.10.0` |
| `undici` | [GHSA-v3r7-h72x-cjcm](https://github.com/advisories/GHSA-v3r7-h72x-cjcm) — cookie attribute injection via unsanitized domain/setCookie | Moderate | same path | `8.7.0` → `8.10.0` |
| `fast-uri` | [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) — host confusion via backslash authority introducer | High | `@commitlint/*` / `@vscode/vsce` (secretlint) → `ajv` → `fast-uri` | `4.1.1` → `4.1.2` |
| `postcss` | [GHSA-fxqj-rqcc-2cmp](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp) — incomplete fix, arbitrary `.map` file read via sourceMappingURL | Moderate | `vitest`/`@vitest/coverage-v8` → `vite` → `postcss` | `8.5.19` → `8.5.25` |

Overrides changed in `pnpm-workspace.yaml`:
```diff
-  fast-uri: '>=3.1.2'
+  fast-uri: '>=4.1.2'
-  postcss: '>=8.5.10'
+  postcss: '>=8.5.23'
-  undici: '>=7.28.0'
+  undici: '>=8.9.0'
```

### Version verification

Each target version was confirmed to exist on the npm registry before applying, via `npm view <pkg> versions --json`:
- `undici`: `8.9.0` and `8.10.0` both present; pnpm resolved to latest `8.10.0`.
- `fast-uri`: `4.1.2` present (also the latest 4.x at time of audit).
- `postcss`: `8.5.23` through `8.5.25` present; pnpm resolved to latest `8.5.25`.

### Compatibility check

All three are transitive dev dependencies with only one resolved version each in the tree (`pnpm why <pkg>` confirmed no duplicates). Their direct parents' declared ranges already tolerated the bump:
- `cheerio` declares `undici: ^7.19.0`, but the pre-existing override already forced `8.7.0` (a range violation predating this PR) — `8.10.0` introduces no new incompatibility.
- `ajv` declares `fast-uri: ^3.0.1`, likewise already overridden past that range to `4.1.1` — `4.1.2` is a patch bump within the already-forced major.
- `vite` declares `postcss: ^8.5.17`, and `8.5.25` satisfies that range natively (no override violation at all here).

`pnpm install` after the change reported **no new peer-dependency or ERESOLVE-style warnings** beyond one pre-existing, unrelated `eslint-plugin-import` / `eslint@10` peer mismatch (confirmed via lockfile diff — no `eslint` lines touched by this change).

## Type of change

- [x] Bug fix (dependency security)
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] CI/build tooling
- [x] Maintenance

## Verification

- [x] `pnpm run lint` — 0 errors, 2 pre-existing warnings in `codeAnalysisService.ts` (unrelated file, not touched)
- [x] `pnpm run build` — succeeds, bundle sizes unchanged
- [x] `pnpm run test:unit` — **124/124 passed**
- [ ] `pnpm run test:unit:coverage` — not run (not required by audit scope)
- [ ] `pnpm run test:integration` — skipped, no display/xvfb available in this environment
- [ ] Manual VS Code Extension Development Host check — N/A, no runtime code changed

### Final `pnpm audit --audit-level=low`

```
No known vulnerabilities found
```

## Screenshots or recordings

N/A — dependency-only change, no UI impact.

## Checklist

- [x] I updated docs or changelog entries when user-facing behavior changed. (`CHANGELOG.md` under `[Unreleased] > Fixed`)
- [x] I avoided generated output in `dist/`, `out-test/`, and compiled `.js`/`.map` files.
- [x] I kept the PR focused and within the repository commit-size guidance. (3 files, 19 changed lines)


---
_Generated by [Claude Code](https://claude.ai/code/session_01D9Epc2seEfCjjJdwKuQLaj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated dependency requirements for `fast-uri`, `postcss`, and `undici` to address vulnerable versions.
  * Confirmed that the low-severity security audit reports no remaining vulnerabilities.

* **Documentation**
  * Added an Unreleased changelog entry documenting the dependency security updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->