### PR TITLE
fix(security): remediate npm audit findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated CLAUDE.md to correctly document that `codeAnalysisService` uses `@babel/parser` (not TypeScript Compiler API)
 - **Security audit remediation**: Tightened pnpm overrides for `js-yaml` (`>=4.1.2` → `>=5.2.2`) and `brace-expansion` (`>=5.0.6` → `>=5.0.8`) — the prior ranges were resolving to vulnerable versions (`js-yaml@5.2.1`, `brace-expansion@5.0.7`) because they only set a floor without excluding the vulnerable window. `pnpm audit --audit-level=low` now reports zero vulnerabilities.
 - **Security audit remediation**: Tightened pnpm overrides for `undici` (`>=7.28.0` → `>=8.9.0`), `fast-uri` (`>=3.1.2` → `>=4.1.2`), and `postcss` (`>=8.5.10` → `>=8.5.23`) — the prior ranges were resolving to vulnerable versions (`undici@8.7.0`, `fast-uri@4.1.1`, `postcss@8.5.19`) because they only set a floor without excluding the vulnerable window. `pnpm audit --audit-level=low` now reports zero vulnerabilities.
+- **Security audit remediation**: Added pnpm override for `nanoid` (`>=3.3.17 <4`) — transitive dependency of `postcss` (via `vite`/`vitest`) resolved to the vulnerable `nanoid@3.3.16` (GHSA-2v37-7h3g-55p8, high severity: custom generators can loop indefinitely when size is zero). The range is capped below `4` because `nanoid` v4+ dropped CommonJS support and an unbounded `>=3.3.17` override resolved to `nanoid@6.0.1`, which is incompatible with `postcss`'s `^3.3.7` requirement. `pnpm audit --audit-level=low` now reports zero vulnerabilities.
 
 ## [2.1.3] - 2026-07-20
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ overrides:
   undici: '>=8.9.0'
   vite: '>=6.4.3'
   js-yaml: '>=5.2.2'
+  nanoid: '>=3.3.17 <4'
 
 importers:
 
@@ -2476,8 +2477,8 @@ packages:
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -5996,7 +5997,7 @@ snapshots:
 
   mute-stream@0.0.8: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   napi-build-utils@2.0.0:
     optional: true
@@ -6238,7 +6239,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,3 +20,4 @@ overrides:
   undici: '>=8.9.0'
   vite: '>=6.4.3'
   js-yaml: '>=5.2.2'
+  nanoid: '>=3.3.17 <4'


### PR DESCRIPTION
## Summary

Daily `pnpm audit` run found one high-severity advisory. Adds a pnpm override to pin the vulnerable transitive dependency to a patched version within its existing major line.

### Vulnerability fixed

| CVE / Advisory | Package | Severity | Old → New | Path |
| --- | --- | --- | --- | --- |
| [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) | `nanoid` | High | `3.3.16` → `3.3.17` | `.>vitest>vite>postcss>nanoid` (dev-only, via `vitest`/`vite`) |

**Advisory:** custom `nanoid` generators can loop indefinitely when `size` is zero (CWE-835).

**Remedy:** Added `nanoid: '>=3.3.17 <4'` to `pnpm-workspace.yaml` `overrides` (transitive dep of `postcss`, not a direct dependency — least-disruptive fix per project convention).

**Why the upper bound:** An unbounded `nanoid: '>=3.3.17'` override resolved to `nanoid@6.0.1` (confirmed via `npm view nanoid versions --json`, which lists `6.0.1` as latest). `nanoid` v4+ dropped CommonJS support, and `postcss` declares `nanoid: ^3.3.7` — jumping to v6 breaks that peer's actual requirement despite pnpm allowing it under a bare `>=` range. Capping at `<4` keeps resolution on the patched `3.3.17`, verified with `npm view nanoid@3.3.17 version`.

## Type of change

- [x] Bug fix (security)
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] CI/build tooling
- [ ] Maintenance

## Verification

- [x] `pnpm run lint` — 0 errors (2 pre-existing warnings in `codeAnalysisService.ts`, unrelated to this change, confirmed present before the change too)
- [x] `pnpm run build` — succeeds, bundle sizes unchanged
- [x] `pnpm run test:unit` — 124/124 tests passed across 13 files
- [ ] `pnpm run test:unit:coverage` — not run (not required by audit workflow)
- [ ] `pnpm run test:integration` — skipped (requires display/xvfb, not available in this environment)
- [ ] Manual VS Code Extension Development Host check — not applicable (dev-only transitive dependency change, no runtime code touched)

### `pnpm audit --audit-level=low` — before

```
1 vulnerabilities found
Severity: 1 high
  high: nanoid custom generators can loop indefinitely when size is zero
  Package: nanoid
  Vulnerable versions: <3.3.17
  Patched versions: >=3.3.17
  Path: .>@vitest/coverage-v8>vitest>@vitest/mocker>vite>postcss>nanoid (+ 3 more paths)
```

### `pnpm audit --audit-level=low` — after

```
No known vulnerabilities found
```

### `pnpm run build` — result

```
✅ Build completed successfully!
📦 Main bundle (optimized): 469.23 KB
📦 Lazy services total: 626.64 KB
📦 Total size: 1095.87 KB
```

### `pnpm run test:unit` — result

```
 Test Files  13 passed (13)
      Tests  124 passed (124)
```

### Peer dependency check

`pnpm peers check` reports one unmet peer (`eslint-plugin-import` wants `eslint <=9`, installed `eslint@10.7.0`) — confirmed **pre-existing** and unaffected by this change (reproduced identically with the change stashed out). No new peer-dependency or ERESOLVE-style conflicts introduced.

## Screenshots or recordings

N/A — dependency-only change, no UI impact.

## Checklist

- [x] I updated docs or changelog entries when user-facing behavior changed. (`CHANGELOG.md` Unreleased → Fixed)
- [x] I avoided generated output in `dist/`, `out-test/`, and compiled `.js`/`.map` files.
- [x] I kept the PR focused and within the repository commit-size guidance. (3 files, 7 insertions / 4 deletions, single commit)

---
_Generated by [Claude Code](https://claude.ai/code/session_019hodtrPboqPtpzQXH5tBnB)_