### PR TITLE
fix(security): remediate npm audit findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated CLAUDE.md to correctly document that `codeAnalysisService` uses `@babel/parser` (not TypeScript Compiler API)
 - **Security audit remediation**: Tightened pnpm overrides for `js-yaml` (`>=4.1.2` → `>=5.2.2`) and `brace-expansion` (`>=5.0.6` → `>=5.0.8`) — the prior ranges were resolving to vulnerable versions (`js-yaml@5.2.1`, `brace-expansion@5.0.7`) because they only set a floor without excluding the vulnerable window. `pnpm audit --audit-level=low` now reports zero vulnerabilities.
 - **Security audit remediation**: Tightened pnpm overrides for `undici` (`>=7.28.0` → `>=8.9.0`), `fast-uri` (`>=3.1.2` → `>=4.1.2`), and `postcss` (`>=8.5.10` → `>=8.5.23`) — the prior ranges were resolving to vulnerable versions (`undici@8.7.0`, `fast-uri@4.1.1`, `postcss@8.5.19`) because they only set a floor without excluding the vulnerable window. `pnpm audit --audit-level=low` now reports zero vulnerabilities.
+- **Security audit remediation**: Added pnpm override for `nanoid` (`^3.3.17`) — the transitive `postcss` → `nanoid@3.3.16` resolution was vulnerable to indefinite loops in custom generators with size zero ([GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8)). Pinned within `postcss`'s declared `^3.3.16` range to avoid an unnecessary major bump. `pnpm audit --audit-level=low` now reports zero vulnerabilities.
 
 ## [2.1.3] - 2026-07-20
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ overrides:
   undici: '>=8.9.0'
   vite: '>=6.4.3'
   js-yaml: '>=5.2.2'
+  nanoid: ^3.3.17
 
 importers:
 
@@ -2476,8 +2477,8 @@ packages:
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -5996,7 +5997,7 @@ snapshots:
 
   mute-stream@0.0.8: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   napi-build-utils@2.0.0:
     optional: true
@@ -6238,7 +6239,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,3 +20,4 @@ overrides:
   undici: '>=8.9.0'
   vite: '>=6.4.3'
   js-yaml: '>=5.2.2'
+  nanoid: '^3.3.17'


### PR DESCRIPTION
## Summary

Daily `pnpm audit` found 1 advisory (high severity), in a dev-only transitive dependency.

| Package | Advisory | Severity | Path | Old → New |
|---|---|---|---|---|
| `nanoid` | [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) — custom generators can loop indefinitely when size is zero | High | `@vitest/coverage-v8` / `vitest` → `vite` → `postcss` → `nanoid` | `3.3.16` → `3.3.18` |

Vulnerable range: `<3.3.17`. Patched range: `>=3.3.17`.

Override added to `pnpm-workspace.yaml`:
```diff
   vite: '>=6.4.3'
   js-yaml: '>=5.2.2'
+  nanoid: '^3.3.17'
```

### Version verification

Confirmed `nanoid@3.3.17` exists on the npm registry via `npm view nanoid versions --json` and `npm view nanoid@3.3.17` before applying. `postcss@8.5.25` declares `nanoid: ^3.3.16` as its only dependency (`npm view postcss@8.5.25 dependencies`), so an initial broader override of `>=3.3.17` was rejected in favor of `^3.3.17` — the broader range let pnpm jump to `nanoid@6.0.1`, a major bump outside what `postcss` actually wants. The tightened `^3.3.17` override resolves to `nanoid@3.3.18`, staying within `postcss`'s declared range while excluding the vulnerable window.

### Compatibility check

`pnpm why nanoid` confirms a single resolved version (`3.3.18`) in the tree, reached only via `postcss` → `vite` → `vitest`/`@vitest/coverage-v8` (dev-only). `pnpm install` reports no new peer-dependency or ERESOLVE-style warnings — the only peer warning present (`eslint-plugin-import` wanting `eslint <=9`, `eslint@10.7.0` installed) is pre-existing and unrelated, confirmed via `pnpm peers check` on `main` before this change (same warning, same packages).

## Type of change

- [x] Bug fix (dependency security)
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] CI/build tooling
- [x] Maintenance

## Verification

- [x] `pnpm run lint` — 0 errors, 2 pre-existing warnings in `codeAnalysisService.ts` (unrelated file, not touched)
- [x] `pnpm run build` — succeeds
- [x] `pnpm run test:unit` — **124/124 passed**
- [ ] `pnpm run test:unit:coverage` — not run (not required by audit scope)
- [ ] `pnpm run test:integration` — skipped, no display/xvfb available in this environment
- [ ] Manual VS Code Extension Development Host check — N/A, no runtime code changed

### Final `pnpm audit --audit-level=low`

```
No known vulnerabilities found
```

## Screenshots or recordings

N/A — dependency-only change, no UI impact.

## Checklist

- [x] I updated docs or changelog entries when user-facing behavior changed. (`CHANGELOG.md` under `[Unreleased] > Fixed`)
- [x] I avoided generated output in `dist/`, `out-test/`, and compiled `.js`/`.map` files.
- [x] I kept the PR focused and within the repository commit-size guidance. (3 files, 11 changed lines)

---
_Generated by [Claude Code](https://claude.ai/code/session_016JwpxLMTv2cPqHhdjAxgvL)_