### PR TITLE
fix(security): remediate npm audit findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CI packaging dry-run**: `build` job now runs `pnpm run package` (`vsce package`) after the build step, across the Node 22/24/26 matrix — validates the VSIX packaging pipeline on every PR/main run instead of only at release time. No upload/publish occurs.
 
 ### Fixed
+- **Security audit remediation**: Added a pnpm override for `nanoid` (`>=3.3.17 <4.0.0`) — the dev-only transitive dependency via `postcss` (used by `vite`/`vitest`) resolved to vulnerable `nanoid@3.3.16` (custom generators can loop indefinitely when size is zero, GHSA-2v37-7h3g-55p8). The override is capped below `4.0.0` to stay within `postcss`'s declared `^3.3.16` range and avoid nanoid's ESM-only major versions. `pnpm audit --audit-level=low` now reports zero vulnerabilities.
 - Daily security audit workflow now manages a single tracking issue instead of creating duplicate issues each day; resolves all 41 stale bot-generated security alert issues
 - Updated CLAUDE.md to correctly document that `codeAnalysisService` uses `@babel/parser` (not TypeScript Compiler API)
 - **Security audit remediation**: Tightened pnpm overrides for `js-yaml` (`>=4.1.2` → `>=5.2.2`) and `brace-expansion` (`>=5.0.6` → `>=5.0.8`) — the prior ranges were resolving to vulnerable versions (`js-yaml@5.2.1`, `brace-expansion@5.0.7`) because they only set a floor without excluding the vulnerable window. `pnpm audit --audit-level=low` now reports zero vulnerabilities.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ overrides:
   undici: '>=8.9.0'
   vite: '>=6.4.3'
   js-yaml: '>=5.2.2'
+  nanoid: '>=3.3.17 <4.0.0'
 
 importers:
 
@@ -2476,8 +2477,8 @@ packages:
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -5996,7 +5997,7 @@ snapshots:
 
   mute-stream@0.0.8: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   napi-build-utils@2.0.0:
     optional: true
@@ -6238,7 +6239,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,3 +20,4 @@ overrides:
   undici: '>=8.9.0'
   vite: '>=6.4.3'
   js-yaml: '>=5.2.2'
+  nanoid: '>=3.3.17 <4.0.0'


### PR DESCRIPTION
## Summary

Daily NPM-ecosystem vulnerability audit found 1 high-severity finding and fixed it via a pnpm override.

- **CVE/Advisory**: [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) — nanoid: custom generators can loop indefinitely when size is zero
- **Package**: `nanoid` (dev-only transitive dependency via `postcss` → `vite` → `vitest`/`@vitest/coverage-v8`)
- **Vulnerable range**: `<3.3.17`
- **Resolved**: `3.3.16` → `3.3.18` (old -> new)
- **Fix**: added `nanoid: '>=3.3.17 <4.0.0'` to `pnpm-workspace.yaml` `overrides`

### Why this range and not a bare `>=3.3.17`

An initial attempt with `>=3.3.17` resolved to `nanoid@6.0.1` (latest), which:
- Violates `postcss@8.5.25`'s own declared dependency range (`^3.3.16`)
- Risks breaking `postcss`'s CommonJS `require('nanoid')` since nanoid's later majors are ESM-only

Capping at `<4.0.0` keeps the fix inside `postcss`'s declared range and resolves to `3.3.18` (the latest 3.x patch, tag `legacy`), which is outside the vulnerable window and least disruptive.

### Version verification (`npm view`)

```
$ npm view nanoid@3.3.17
nanoid@3.3.17 | MIT | deps: none | versions: 132
dist-tags: latest: 6.0.1, legacy: 3.3.18

$ npm view nanoid@3.3.18 version dist.integrity
version = '3.3.18'
dist.integrity = 'sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=='
```

Both versions exist on the registry and are outside the vulnerable `<3.3.17` range.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] CI/build tooling
- [ ] Maintenance

## Verification

- [x] `pnpm run lint` — 0 errors (2 pre-existing warnings in `codeAnalysisService.ts`, unrelated to this change)
- [x] `pnpm run build` — succeeded, main bundle 469.23 KB
- [x] `pnpm run test:unit` — 124/124 tests passed across 13 files
- [ ] `pnpm run test:unit:coverage` — not run (not required by audit workflow)
- [ ] `pnpm run test:integration` — skipped, no display/xvfb available in this environment
- [ ] Manual VS Code Extension Development Host check — not applicable, dependency-only change

### `pnpm audit --audit-level=low`

Before:
```
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ high                │ nanoid: custom generators can loop indefinitely when   │
│                     │ size is zero                                           │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ nanoid                                                 │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ <3.3.17                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=3.3.17                                               │
└─────────────────────┴────────────────────────────────────────────────────────┘
1 vulnerabilities found
Severity: 1 high
```

After:
```
No known vulnerabilities found
```

### `pnpm run build`
```
✅ Build completed successfully!
📦 Main bundle (optimized): 469.23 KB
📦 Lazy services total: 626.64 KB
📦 Total size: 1095.87 KB
```

### `pnpm run test:unit`
```
 Test Files  13 passed (13)
      Tests  124 passed (124)
```

### Peer dependency check

`pnpm peers check` reports one pre-existing unmet-peer warning (`eslint-plugin-import@2.32.0` wants `eslint` `^2..^9`, installed `10.7.0`) — verified present on unmodified `main` before this change, unrelated to the nanoid fix. No new peer-dependency or ERESOLVE-style conflicts introduced.

## Screenshots or recordings

N/A — dependency-only change, no UI impact.

## Checklist

- [x] I updated docs or changelog entries when user-facing behavior changed. (`CHANGELOG.md` Unreleased/Fixed)
- [x] I avoided generated output in `dist/`, `out-test/`, and compiled `.js`/`.map` files.
- [x] I kept the PR focused and within the repository commit-size guidance. (1 commit, 3 files)


---
_Generated by [Claude Code](https://claude.ai/code/session_01TPMUebiWY2BLnFFRfbAEbn)_