### PR TITLE
fix(security): remediate npm audit findings

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ overrides:
   undici: '>=8.9.0'
   vite: '>=6.4.3'
   js-yaml: '>=5.2.2'
+  nanoid: 3.3.18
 
 importers:
 
@@ -2476,8 +2477,8 @@ packages:
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -5996,7 +5997,7 @@ snapshots:
 
   mute-stream@0.0.8: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   napi-build-utils@2.0.0:
     optional: true
@@ -6238,7 +6239,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,3 +20,4 @@ overrides:
   undici: '>=8.9.0'
   vite: '>=6.4.3'
   js-yaml: '>=5.2.2'
+  nanoid: '3.3.18'


### PR DESCRIPTION
## Summary

Daily `pnpm audit` found one high-severity advisory: **nanoid 3.3.16** ("custom generators can loop indefinitely when size is zero", [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8), CWE-835). Patched in `>=3.3.17`.

- **Package:** `nanoid`
- **Path:** `additional-context-menus` → `vitest`/`@vitest/coverage-v8` → `vite` → `postcss` → `nanoid` (dev-only, transitive; brought in by the vitest/vite coverage toolchain)
- **Vulnerable range:** `<3.3.17`
- **Fix:** added `nanoid: '3.3.18'` to `pnpm-workspace.yaml` `overrides` (following the existing override pattern in this file). Pinned to an exact version rather than an unbounded `>=3.3.17` range after confirming an unbounded floor let pnpm resolve to `nanoid@6.0.1` — a major bump outside what `postcss@8.5.25`'s own `^3.3.16` dependency range expects. `3.3.18` is npm's `legacy` dist-tag for the 3.x line and satisfies postcss's caret range.
- **Verified via registry:** `npm view nanoid versions --json` confirms `3.3.17` and `3.3.18` both exist; `npm view postcss@8.5.25 dependencies` confirms postcss depends on `nanoid: ^3.3.16`, so `3.3.18` stays within its accepted range.

No direct dependency in `package.json` needed changes — this was purely a transitive/dev dependency.

## Type of change

- [x] Bug fix (security)
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] CI/build tooling
- [ ] Maintenance

## Verification

- [x] `pnpm run lint` — 0 errors (2 pre-existing warnings in `src/services/codeAnalysisService.ts`, unrelated to this change)
- [x] `pnpm run build` — succeeds, bundle sizes unchanged
- [x] `pnpm run test:unit` — 124/124 tests passed across 13 files
- [ ] `pnpm run test:unit:coverage` — not run (not required by this task)
- [ ] `pnpm run test:integration` — skipped, no display/xvfb available in this environment
- [ ] Manual VS Code Extension Development Host check — not applicable, no runtime code changed

### Audit output (before → after)

Before:
```
1 vulnerabilities found
Severity: 1 high
nanoid: custom generators can loop indefinitely when size is zero (<3.3.17)
```

After:
```
$ pnpm audit --audit-level=low
No known vulnerabilities found
```

### Peer dependencies

`pnpm peers check` shows one unmet peer (`eslint-plugin-import@2.32.0` wants `eslint@^2..^9`, installed `eslint@10.7.0`) — pre-existing on `main` before this change, unrelated to the nanoid override, not touched by this PR.

## Screenshots or recordings

N/A — no UI changes.

## Checklist

- [x] I updated docs or changelog entries when user-facing behavior changed. (N/A — dev-only dependency fix, no user-facing behavior change; CLAUDE.md/CHANGELOG.md not touched since no architecture/command/feature changed)
- [x] I avoided generated output in `dist/`, `out-test/`, and compiled `.js`/`.map` files.
- [x] I kept the PR focused and within the repository commit-size guidance. (2 files changed: `pnpm-workspace.yaml`, `pnpm-lock.yaml`)

---
_Generated by [Claude Code](https://claude.ai/code/session_0195QyBuDgcDqg7S9mMAEtrr)_