### PR TITLE
fix(security): remediate npm audit findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CI packaging dry-run**: `build` job now runs `pnpm run package` (`vsce package`) after the build step, across the Node 22/24/26 matrix — validates the VSIX packaging pipeline on every PR/main run instead of only at release time. No upload/publish occurs.
 
 ### Fixed
+- **Security audit remediation**: Added a pnpm override for `nanoid` (`>=3.3.17`) — the dev-only transitive dependency (`vitest`/`vite`/`postcss`) resolved to `nanoid@3.3.16`, vulnerable to indefinite looping in custom generators when size is zero ([GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8)). `pnpm audit --audit-level=low` now reports zero vulnerabilities.
 - Daily security audit workflow now manages a single tracking issue instead of creating duplicate issues each day; resolves all 41 stale bot-generated security alert issues
 - Updated CLAUDE.md to correctly document that `codeAnalysisService` uses `@babel/parser` (not TypeScript Compiler API)
 - **Security audit remediation**: Tightened pnpm overrides for `js-yaml` (`>=4.1.2` → `>=5.2.2`) and `brace-expansion` (`>=5.0.6` → `>=5.0.8`) — the prior ranges were resolving to vulnerable versions (`js-yaml@5.2.1`, `brace-expansion@5.0.7`) because they only set a floor without excluding the vulnerable window. `pnpm audit --audit-level=low` now reports zero vulnerabilities.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ overrides:
   undici: '>=8.9.0'
   vite: '>=6.4.3'
   js-yaml: '>=5.2.2'
+  nanoid: '>=3.3.17'
 
 importers:
 
@@ -2476,9 +2477,9 @@ packages:
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+  nanoid@6.0.1:
+    resolution: {integrity: sha512-3wVS3i51pE2pi1k5FFL/95BGfVS0kSsvDVuGXHOtxox/TywUmtgq+3qiTOTbs9J7KfHaXPiN171k/A6dBnaXFw==}
+    engines: {node: ^22 || ^24 || >=26}
     hasBin: true
 
   napi-build-utils@2.0.0:
@@ -5996,7 +5997,7 @@ snapshots:
 
   mute-stream@0.0.8: {}
 
-  nanoid@3.3.16: {}
+  nanoid@6.0.1: {}
 
   napi-build-utils@2.0.0:
     optional: true
@@ -6238,7 +6239,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 6.0.1
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,3 +20,4 @@ overrides:
   undici: '>=8.9.0'
   vite: '>=6.4.3'
   js-yaml: '>=5.2.2'
+  nanoid: '>=3.3.17'


### PR DESCRIPTION
## Summary

Daily NPM-ecosystem vulnerability audit found one high-severity advisory. Fixed via a pnpm override.

### CVE remediated

| Package | Advisory | Severity | Vulnerable range | Patched range | Old → New |
| --- | --- | --- | --- | --- | --- |
| `nanoid` | [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) — custom generators can loop indefinitely when size is zero | high | `<3.3.17` | `>=3.3.17` | `3.3.16` → `6.0.1` (resolved via `nanoid: '>=3.3.17'` override) |

`nanoid` is a dev-only transitive dependency pulled in via `vitest > vite > postcss > nanoid` (test tooling only, not part of the packaged extension). Added `nanoid: '>=3.3.17'` to `pnpm-workspace.yaml` `overrides`, following this repo's existing pattern for transitive-dependency CVEs.

**Version verification:** confirmed `nanoid@3.3.17` (and the resolved `6.0.1`) exist on the npm registry via `npm view nanoid versions --json` / `npm view nanoid@3.3.17`. `nanoid@6.0.1` has zero dependencies of its own (`deps: none`) and declares `engines: {node: ^22 || ^24 || >=26}`, compatible with this repo's `>=22` requirement — no peer/engine conflicts introduced. `pnpm peers check` shows one pre-existing unrelated warning (`eslint-plugin-import` wanting `eslint <=9`, installed `10.7.0`) that is untouched by this change (confirmed via lockfile diff scoped to `nanoid` only).

## Type of change

- [x] Bug fix (security)
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] CI/build tooling
- [ ] Maintenance

## Verification

- [x] `pnpm run lint` — 0 errors, 2 pre-existing warnings unrelated to this change (`codeAnalysisService.ts`, not touched)
- [x] `pnpm run build` — succeeds
- [x] `pnpm run test:unit` — 124/124 tests passed (13 files)
- [ ] `pnpm run test:unit:coverage` — not run (not required by audit workflow)
- [ ] `pnpm run test:integration` — skipped, no display/xvfb available in this environment
- [ ] Manual VS Code Extension Development Host check — not applicable (dependency-only change, no source changes)

### Final `pnpm audit --audit-level=low`

```
No known vulnerabilities found
```

## Screenshots or recordings

N/A — dependency-only change, no VS Code UI changes.

## Checklist

- [x] I updated docs or changelog entries when user-facing behavior changed. (`CHANGELOG.md` under `[Unreleased] > Fixed`)
- [x] I avoided generated output in `dist/`, `out-test/`, and compiled `.js`/`.map` files.
- [x] I kept the PR focused and within the repository commit-size guidance. (3 files changed, 8 insertions, 5 deletions)


---
_Generated by [Claude Code](https://claude.ai/code/session_01V6WLgHQeVNGSVnqwRWVXW8)_