### PR TITLE
fix(security): remediate npm audit findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CI packaging dry-run**: `build` job now runs `pnpm run package` (`vsce package`) after the build step, across the Node 22/24/26 matrix — validates the VSIX packaging pipeline on every PR/main run instead of only at release time. No upload/publish occurs.
 
 ### Fixed
+- **Security audit remediation**: Added a pnpm override for `nanoid` (`>=3.3.18 <4.0.0`) — `postcss`'s transitive `nanoid@3.3.16` was vulnerable to indefinite loops from custom generators with a zero size (GHSA-2v37-7h3g-55p8). The upper bound keeps `nanoid` within the 3.x line `postcss` declares (`^3.3.16`), avoiding the breaking ESM-only 4.x+ releases. `pnpm audit --audit-level=low` now reports zero vulnerabilities.
 - Daily security audit workflow now manages a single tracking issue instead of creating duplicate issues each day; resolves all 41 stale bot-generated security alert issues
 - Updated CLAUDE.md to correctly document that `codeAnalysisService` uses `@babel/parser` (not TypeScript Compiler API)
 - **Security audit remediation**: Tightened pnpm overrides for `js-yaml` (`>=4.1.2` → `>=5.2.2`) and `brace-expansion` (`>=5.0.6` → `>=5.0.8`) — the prior ranges were resolving to vulnerable versions (`js-yaml@5.2.1`, `brace-expansion@5.0.7`) because they only set a floor without excluding the vulnerable window. `pnpm audit --audit-level=low` now reports zero vulnerabilities.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ overrides:
   undici: '>=8.9.0'
   vite: '>=6.4.3'
   js-yaml: '>=5.2.2'
+  nanoid: '>=3.3.18 <4.0.0'
 
 importers:
 
@@ -2476,8 +2477,8 @@ packages:
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -5996,7 +5997,7 @@ snapshots:
 
   mute-stream@0.0.8: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   napi-build-utils@2.0.0:
     optional: true
@@ -6238,7 +6239,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,3 +20,4 @@ overrides:
   undici: '>=8.9.0'
   vite: '>=6.4.3'
   js-yaml: '>=5.2.2'
+  nanoid: '>=3.3.18 <4.0.0'


### PR DESCRIPTION
## Summary

Daily `pnpm audit` found one high-severity finding, now resolved:

- **`nanoid` — GHSA-2v37-7h3g-55p8** (high): custom generators can loop indefinitely when size is zero.
  - Package: `nanoid` (transitive: `postcss` → `vite` → `vitest`/`@vitest/mocker`/`@vitest/coverage-v8`, dev-only)
  - Vulnerable range: `<3.3.18`
  - Patched range: `>=3.3.18`
  - Resolved version: `nanoid@3.3.16` → `nanoid@3.3.18`
  - Fix: added a pnpm override `nanoid: '>=3.3.18 <4.0.0'` in `pnpm-workspace.yaml`. The upper bound `<4.0.0` keeps the resolution inside the `^3.3.16` range `postcss@8.5.25` itself declares, avoiding the breaking, ESM-only `nanoid` 4.x/5.x/6.x lines.
  - Verified `3.3.18` exists and is safe via `npm view nanoid versions --json` and `npm view nanoid@3.3.18` before applying.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] CI/build tooling
- [ ] Maintenance

## Verification

- [x] `pnpm run lint` — 0 errors (2 pre-existing warnings in `codeAnalysisService.ts`, unrelated to this change)
- [x] `pnpm run build` — succeeded, bundle sizes unchanged
- [x] `pnpm run test:unit` — 124/124 passed
- [ ] `pnpm run test:unit:coverage` — not run (not required for this change)
- [ ] `pnpm run test:integration` — skipped, no display/xvfb available in this environment
- [ ] Manual VS Code Extension Development Host check — not applicable, no runtime code changed

### Final `pnpm audit --audit-level=low`

Before:
```
1 vulnerabilities found
Severity: 1 high
```

After:
```
No known vulnerabilities found
```

### Build output
```
✅ Build completed successfully!
📦 Main bundle (optimized): 469.23 KB
📦 Total size: 1095.87 KB
```

### Unit test output
```
Test Files  13 passed (13)
     Tests  124 passed (124)
```

### Peer dependency check

`pnpm peers check` reports one pre-existing, unrelated warning (`eslint-plugin-import@2.32.0` wants `eslint` ^2–^9, installed `eslint@10.7.0`) — present before this change and out of scope for this audit.

## Screenshots or recordings

N/A — no UI changes.

## Checklist

- [x] I updated docs or changelog entries when user-facing behavior changed. (`CHANGELOG.md` Unreleased → Fixed)
- [x] I avoided generated output in `dist/`, `out-test/`, and compiled `.js`/`.map` files.
- [x] I kept the PR focused and within the repository commit-size guidance. (3 files changed, 7 insertions, 4 deletions)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSKa4Vqq4SZMacV1G6jTF5)_