### PR TITLE
fix(security): remediate npm audit findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated CLAUDE.md to correctly document that `codeAnalysisService` uses `@babel/parser` (not TypeScript Compiler API)
 - **Security audit remediation**: Tightened pnpm overrides for `js-yaml` (`>=4.1.2` → `>=5.2.2`) and `brace-expansion` (`>=5.0.6` → `>=5.0.8`) — the prior ranges were resolving to vulnerable versions (`js-yaml@5.2.1`, `brace-expansion@5.0.7`) because they only set a floor without excluding the vulnerable window. `pnpm audit --audit-level=low` now reports zero vulnerabilities.
 - **Security audit remediation**: Tightened pnpm overrides for `undici` (`>=7.28.0` → `>=8.9.0`), `fast-uri` (`>=3.1.2` → `>=4.1.2`), and `postcss` (`>=8.5.10` → `>=8.5.23`) — the prior ranges were resolving to vulnerable versions (`undici@8.7.0`, `fast-uri@4.1.1`, `postcss@8.5.19`) because they only set a floor without excluding the vulnerable window. `pnpm audit --audit-level=low` now reports zero vulnerabilities.
+- **Security audit remediation**: Added a pnpm override pinning transitive dependency `nanoid` to `>=3.3.18 <4.0.0` (GHSA-2v37-7h3g-55p8, high severity — custom generators could loop indefinitely when size is zero). Bounded above `4.0.0` to stay within `postcss`'s declared `^3.3.16` dependency range and avoid an unintended major bump to `nanoid` 6.x. `pnpm audit --audit-level=low` now reports zero vulnerabilities.
 
 ## [2.1.3] - 2026-07-20
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ overrides:
   undici: '>=8.9.0'
   vite: '>=6.4.3'
   js-yaml: '>=5.2.2'
+  nanoid: '>=3.3.18 <4.0.0'
 
 importers:
 
@@ -2476,8 +2477,8 @@ packages:
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -5996,7 +5997,7 @@ snapshots:
 
   mute-stream@0.0.8: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   napi-build-utils@2.0.0:
     optional: true
@@ -6238,7 +6239,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,3 +20,4 @@ overrides:
   undici: '>=8.9.0'
   vite: '>=6.4.3'
   js-yaml: '>=5.2.2'
+  nanoid: '>=3.3.18 <4.0.0'


### PR DESCRIPTION
## Summary

Daily `pnpm audit` scan found one high-severity advisory. Fixed via a pnpm override.

### CVE details

| Package | Severity | Vulnerable range | Patched range | Advisory |
|---|---|---|---|---|
| `nanoid` | High | `<3.3.18` | `>=3.3.18` | [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) — custom generators can loop indefinitely when size is zero |

**Dependency path:** `additional-context-menus (devDependencies) > @vitest/coverage-v8 / vitest > vite > postcss > nanoid` (transitive dev-only dependency, resolved to `nanoid@3.3.16`).

**Fix:** Added `nanoid: '>=3.3.18 <4.0.0'` to `pnpm-workspace.yaml` `overrides`. Bounded above `4.0.0` deliberately — an unbounded `>=3.3.18` override resolved pnpm to `nanoid@6.0.1` (latest), which conflicts with `postcss`'s declared `nanoid: ^3.3.16` dependency and would have pulled in nanoid's ESM-only v4+ API into a package that expects the v3 API. The bounded range resolves cleanly to `nanoid@3.3.18`, the minimal patched version, keeping it inside postcss's expected range.

**Version verification (`npm view nanoid ...`):**
- `npm view nanoid versions --json` confirms `3.3.18` exists on the registry.
- `npm view nanoid@3.3.18` confirms it's a real, published version (no deps, MIT license).
- Confirmed via `pnpm why nanoid` after install that resolution lands on `nanoid@3.3.18`, not a higher major.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] CI/build tooling
- [x] Maintenance

## Verification

- [x] `pnpm run lint` — 0 errors (2 pre-existing warnings in `codeAnalysisService.ts`, unrelated to this change)
- [x] `pnpm run build` — succeeds, bundle sizes unchanged
- [x] `pnpm run test:unit` — 124/124 tests passed across 13 test files
- [ ] `pnpm run test:unit:coverage` — not run (not required by this PR's scope)
- [ ] `pnpm run test:integration` — skipped, no display/xvfb available in this environment
- [ ] Manual VS Code Extension Development Host check — not applicable, no runtime code changed

### Final `pnpm audit --audit-level=low` output

```
No known vulnerabilities found
```

### Build output

```
✅ Build completed successfully!
📦 Main bundle (optimized): 469.23 KB
📦 Lazy services total: 626.64 KB
📦 Total size: 1095.87 KB
```

### Unit test output

```
Test Files  13 passed (13)
     Tests  124 passed (124)
```

Also verified `pnpm peers check` reports only a pre-existing, unrelated `eslint-plugin-import` peer warning (confirmed present before this change via `git stash`) — no new peer-dependency conflicts introduced.

## Screenshots or recordings

N/A — dependency-only change, no VS Code UI affected.

## Checklist

- [x] I updated docs or changelog entries when user-facing behavior changed. (`CHANGELOG.md` under Unreleased/Fixed; not user-facing but follows this repo's established convention for security-audit PRs)
- [x] I avoided generated output in `dist/`, `out-test/`, and compiled `.js`/`.map` files.
- [x] I kept the PR focused and within the repository commit-size guidance (2 commits, 3 files total, well under the 10-file/400-line limit).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CiLhQPgtUh4ozDoGjFNWPL)_