### PR TITLE
fix(security): remediate npm audit findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CI packaging dry-run**: `build` job now runs `pnpm run package` (`vsce package`) after the build step, across the Node 22/24/26 matrix — validates the VSIX packaging pipeline on every PR/main run instead of only at release time. No upload/publish occurs.
 
 ### Fixed
+- **Security audit remediation**: Added a pnpm override for `nanoid` (`^3.3.18`) — the prior transitive resolution (`nanoid@3.3.16` via `postcss` → `vite` → `vitest`) was vulnerable to indefinite looping in custom generators when size is zero (GHSA-2v37-7h3g-55p8). `pnpm audit --audit-level=low` now reports zero vulnerabilities.
 - Daily security audit workflow now manages a single tracking issue instead of creating duplicate issues each day; resolves all 41 stale bot-generated security alert issues
 - Updated CLAUDE.md to correctly document that `codeAnalysisService` uses `@babel/parser` (not TypeScript Compiler API)
 - **Security audit remediation**: Tightened pnpm overrides for `js-yaml` (`>=4.1.2` → `>=5.2.2`) and `brace-expansion` (`>=5.0.6` → `>=5.0.8`) — the prior ranges were resolving to vulnerable versions (`js-yaml@5.2.1`, `brace-expansion@5.0.7`) because they only set a floor without excluding the vulnerable window. `pnpm audit --audit-level=low` now reports zero vulnerabilities.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ overrides:
   undici: '>=8.9.0'
   vite: '>=6.4.3'
   js-yaml: '>=5.2.2'
+  nanoid: ^3.3.18
 
 importers:
 
@@ -2476,8 +2477,8 @@ packages:
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -5996,7 +5997,7 @@ snapshots:
 
   mute-stream@0.0.8: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   napi-build-utils@2.0.0:
     optional: true
@@ -6238,7 +6239,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,3 +20,4 @@ overrides:
   undici: '>=8.9.0'
   vite: '>=6.4.3'
   js-yaml: '>=5.2.2'
+  nanoid: '^3.3.18'


### PR DESCRIPTION
## Summary

Daily security audit found one high-severity advisory. Fixed via a pnpm override; app verified intact.

- **`nanoid`**: `GHSA-2v37-7h3g-55p8` (CWE-835) — "custom generators can loop indefinitely when size is zero"
  - Severity: **high**
  - Vulnerable range: `<3.3.18`
  - Patched range: `>=3.3.18`
  - Resolved version: `3.3.16` → `3.3.18`
  - Path: `.>@vitest/coverage-v8>vitest>vite>postcss>nanoid` (dev-only transitive dependency, not shipped in the packaged extension)
  - Fix: added `nanoid: '^3.3.18'` to `pnpm-workspace.yaml` `overrides`. Verified the target version exists and satisfies the rest of the tree via `npm view nanoid versions --json` (confirms `3.3.18` is published) and `npm view postcss@8.5.25 dependencies --json` (confirms `postcss` declares `nanoid: ^3.3.16`, so `3.3.18` is in-range). Used `^3.3.18` rather than `>=3.3.18` to avoid pnpm resolving an unnecessary major bump (`>=3.3.18` was observed to resolve to `nanoid@6.0.1`); `pnpm why nanoid` now confirms a single resolved version, `3.3.18`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] CI/build tooling
- [ ] Maintenance

## Verification

- [x] `pnpm run lint` — 0 errors, 2 pre-existing warnings in `src/services/codeAnalysisService.ts` (`@typescript-eslint/no-unnecessary-condition`), unrelated to this change and unrelated to any file touched here.
- [x] `pnpm run build` — succeeded (`Build completed successfully!`, main bundle 469.23 KB, well under the 100KB core-bundle budget's lazy-service exclusions).
- [x] `pnpm run test:unit` — 124/124 tests passed across 13 files.
- [ ] `pnpm run test:unit:coverage` — not run (not required by the audit workflow).
- [ ] `pnpm run test:integration` — skipped, requires a display/xvfb not available in this environment.
- [ ] Manual VS Code Extension Development Host check — not applicable; change is dev-tooling-only (test/build dependency), no `src/` changes.

### Final `pnpm audit --audit-level=low`

```
No known vulnerabilities found
```

### Peer dependencies

`pnpm install` reports one unrelated pre-existing warning (`eslint-plugin-import@2.32.0` wants `eslint@^2..^9`, installed `eslint@10.7.0`) — confirmed present on `main` before this change via `git stash`; not introduced by this PR. No ERESOLVE-style conflicts.

## Screenshots or recordings

N/A — dependency-only change, no UI impact.

## Checklist

- [x] I updated docs or changelog entries when user-facing behavior changed. (Added a `CHANGELOG.md` entry under `[Unreleased] > Fixed`; no user-facing behavior changed since this is a dev-only transitive dependency.)
- [x] I avoided generated output in `dist/`, `out-test/`, and compiled `.js`/`.map` files.
- [x] I kept the PR focused and within the repository commit-size guidance. (1 commit, 3 files, 7 insertions / 4 deletions.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDWtbNThqHK9N48cML4FvV)_