### PR TITLE
fix(security): remediate npm audit findings (nanoid)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CI packaging dry-run**: `build` job now runs `pnpm run package` (`vsce package`) after the build step, across the Node 22/24/26 matrix — validates the VSIX packaging pipeline on every PR/main run instead of only at release time. No upload/publish occurs.
 
 ### Fixed
+- **Security audit remediation**: Added a pnpm override pinning `nanoid` to `^3.3.18` — the prior transitive resolution (`nanoid@3.3.16`, via `postcss` → `vite` → `vitest`) was vulnerable to a high-severity indefinite-loop issue when a custom generator's size is zero ([GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8)). `pnpm audit --audit-level=low` now reports zero vulnerabilities.
 - Daily security audit workflow now manages a single tracking issue instead of creating duplicate issues each day; resolves all 41 stale bot-generated security alert issues
 - Updated CLAUDE.md to correctly document that `codeAnalysisService` uses `@babel/parser` (not TypeScript Compiler API)
 - **Security audit remediation**: Tightened pnpm overrides for `js-yaml` (`>=4.1.2` → `>=5.2.2`) and `brace-expansion` (`>=5.0.6` → `>=5.0.8`) — the prior ranges were resolving to vulnerable versions (`js-yaml@5.2.1`, `brace-expansion@5.0.7`) because they only set a floor without excluding the vulnerable window. `pnpm audit --audit-level=low` now reports zero vulnerabilities.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ overrides:
   undici: '>=8.9.0'
   vite: '>=6.4.3'
   js-yaml: '>=5.2.2'
+  nanoid: ^3.3.18
 
 importers:
 
@@ -2476,8 +2477,8 @@ packages:
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -5996,7 +5997,7 @@ snapshots:
 
   mute-stream@0.0.8: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   napi-build-utils@2.0.0:
     optional: true
@@ -6238,7 +6239,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,3 +20,4 @@ overrides:
   undici: '>=8.9.0'
   vite: '>=6.4.3'
   js-yaml: '>=5.2.2'
+  nanoid: '^3.3.18'


### PR DESCRIPTION
## Summary

Daily security audit found one high-severity advisory. This PR remediates it via a pnpm override, with no direct `package.json` changes.

### CVE details

| Package | Severity | Vulnerable range | Patched range | Advisory |
| --- | --- | --- | --- | --- |
| `nanoid` | High | `<3.3.18` | `>=3.3.18` | [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) — custom generators can loop indefinitely when size is zero |

- Resolved via: `pnpm-workspace.yaml` `overrides` (dev-only transitive dependency, path `postcss > vite > vitest`) — not a direct dependency, so no `package.json` bump.
- Old → new: `nanoid@3.3.16` → `nanoid@3.3.18`
- Override added: `nanoid: '^3.3.18'` — pinned to the `3.x` line (not the loose `>=3.3.18`, which pnpm resolves to `nanoid@6.0.1`, an ESM-only package incompatible with `postcss`'s declared `^3.3.11` CJS-era dependency). `postcss`'s own `dependencies.nanoid` range (`^3.3.11`) is satisfied by `3.3.18`.

### Version verification (`npm view`)

- `npm view nanoid versions --json` — confirmed `3.3.18` exists on the registry.
- `npm view nanoid@3.3.18 version` / `type main` — confirmed `3.3.18` is real, still CJS-compatible (`main: index.cjs`), matching the tree's existing `nanoid@3.x` shape.
- Confirmed `postcss@8.5.25`'s own manifest declares `nanoid: ^3.3.11`, so `3.3.18` satisfies its peer/dependency constraint without forcing a major bump.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] CI/build tooling
- [ ] Maintenance

## Verification

- [x] `pnpm run lint` — 0 errors, 2 pre-existing warnings in `codeAnalysisService.ts` (unrelated to this change)
- [x] `pnpm run build` — succeeds, main bundle 469.23 KB
- [x] `pnpm run test:unit` — 124/124 tests passed across 13 files
- [ ] `pnpm run test:unit:coverage` — not run (out of scope for this audit)
- [ ] `pnpm run test:integration` — skipped (no display/xvfb available in this environment)
- [ ] Manual VS Code Extension Development Host check — not applicable, no runtime code changed

### Final `pnpm audit --audit-level=low`

```
No known vulnerabilities found
```

### `pnpm run build` output

```
✅ Build completed successfully!
📦 Main bundle (optimized): 469.23 KB
📦 Lazy services total: 626.64 KB
📦 Total size: 1095.87 KB
```

### `pnpm run test:unit` output

```
Test Files  13 passed (13)
     Tests  124 passed (124)
```

## Screenshots or recordings

N/A — dependency-only change, no UI impact.

## Checklist

- [x] I updated docs or changelog entries when user-facing behavior changed. (Added `CHANGELOG.md` entry under `[Unreleased] > Fixed`)
- [x] I avoided generated output in `dist/`, `out-test/`, and compiled `.js`/`.map` files.
- [x] I kept the PR focused and within the repository commit-size guidance. (3 files changed: `pnpm-workspace.yaml`, `pnpm-lock.yaml`, `CHANGELOG.md`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P6yh1jqxNn4KfHjnNvfxvk)_