### PR TITLE
fix(security): remediate npm audit findings (nanoid)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CI packaging dry-run**: `build` job now runs `pnpm run package` (`vsce package`) after the build step, across the Node 22/24/26 matrix — validates the VSIX packaging pipeline on every PR/main run instead of only at release time. No upload/publish occurs.
 
 ### Fixed
+- **Security audit remediation**: Pinned pnpm override for `nanoid` (transitive via `postcss` < `vite` < `vitest`) to `3.3.18` to remediate [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) (custom generators looping indefinitely when size is zero) — `postcss@8.5.25` requires `nanoid@^3.3.16`, so the override is pinned to the exact patched `3.x` release rather than an unbounded `>=` range to avoid an unintended major-version jump. `pnpm audit --audit-level=low` now reports zero vulnerabilities.
 - Daily security audit workflow now manages a single tracking issue instead of creating duplicate issues each day; resolves all 41 stale bot-generated security alert issues
 - Updated CLAUDE.md to correctly document that `codeAnalysisService` uses `@babel/parser` (not TypeScript Compiler API)
 - **Security audit remediation**: Tightened pnpm overrides for `js-yaml` (`>=4.1.2` → `>=5.2.2`) and `brace-expansion` (`>=5.0.6` → `>=5.0.8`) — the prior ranges were resolving to vulnerable versions (`js-yaml@5.2.1`, `brace-expansion@5.0.7`) because they only set a floor without excluding the vulnerable window. `pnpm audit --audit-level=low` now reports zero vulnerabilities.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ overrides:
   undici: '>=8.9.0'
   vite: '>=6.4.3'
   js-yaml: '>=5.2.2'
+  nanoid: 3.3.18
 
 importers:
 
@@ -2476,8 +2477,8 @@ packages:
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -5996,7 +5997,7 @@ snapshots:
 
   mute-stream@0.0.8: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   napi-build-utils@2.0.0:
     optional: true
@@ -6238,7 +6239,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,3 +20,4 @@ overrides:
   undici: '>=8.9.0'
   vite: '>=6.4.3'
   js-yaml: '>=5.2.2'
+  nanoid: '3.3.18'


### PR DESCRIPTION
## Summary

Daily security audit found one advisory. `pnpm audit --audit-level=low` reported:

| Package | Severity | Vulnerable range | Patched range | Path |
| --- | --- | --- | --- | --- |
| `nanoid` | high | `<3.3.18` | `>=3.3.18` | `additional-context-menus > @vitest/coverage-v8 > vitest > vite > postcss > nanoid` (and 3 equivalent paths through `vitest`/`@vitest/mocker`) |

Advisory: [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) — custom `nanoid` generators can loop indefinitely when `size` is zero.

`nanoid` is a dev-only transitive dependency (via `postcss` → `vite` → `vitest`/`@vitest/coverage-v8`); it is not shipped in the extension bundle.

### Fix

- Added a pnpm override in `pnpm-workspace.yaml`: `nanoid: '3.3.18'`.
- **Verified the target version before applying it**: ran `npm view nanoid versions --json` — confirmed `3.3.18` exists on the registry and is the last version in the `3.3.x` line. Confirmed `postcss@8.5.25`'s own dependency range via `npm view postcss@8.5.25 dependencies`, which reported `nanoid: '^3.3.16'` — so `3.3.18` satisfies it.
- Initially tried an unbounded `>=3.3.18` override, but that resolved to `nanoid@6.0.1`, which does **not** satisfy `postcss`'s `^3.3.16` peer/dep range (pnpm still forced it, silently violating the tree). Pinned to the exact patched version `3.3.18` instead to stay within the same major line `postcss` expects and avoid an unintended major-version jump — the least-disruptive fix per repo convention.
- `pnpm why nanoid` confirms a single resolved version, `3.3.18`, used everywhere.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] CI/build tooling
- [ ] Maintenance

## Verification

- [x] `pnpm run lint` — 0 errors (2 pre-existing warnings in `codeAnalysisService.ts`, unrelated to this change, unchanged before/after)
- [x] `pnpm run build` — succeeds, bundle sizes unchanged
- [x] `pnpm run test:unit` — 124/124 tests passed across 13 files
- [ ] `pnpm run test:unit:coverage` — not run (not required by audit workflow)
- [ ] `pnpm run test:integration` — skipped, no display/xvfb available in this environment
- [ ] Manual VS Code Extension Development Host check — not applicable, no runtime code changed

### Final `pnpm audit --audit-level=low`

```
No known vulnerabilities found
```

### Peer dependencies

Confirmed the pre-existing `unmet peer eslint` warning (from `eslint-plugin-import@2.32.0` wanting eslint `^2 || ... || ^9`, installed `eslint@10.7.0`) exists identically on `main` before this change — not introduced by this fix. No new peer-dependency or ERESOLVE-style conflicts were introduced.

## Screenshots or recordings

N/A — no VS Code UI changes.

## Checklist

- [x] I updated docs or changelog entries when user-facing behavior changed. (`CHANGELOG.md` Unreleased/Fixed)
- [x] I avoided generated output in `dist/`, `out-test/`, and compiled `.js`/`.map` files.
- [x] I kept the PR focused and within the repository commit-size guidance. (3 files changed, single commit)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QyUzu8J2wmoEiPtD7HZjxA)_