### PR TITLE
fix(security): remediate npm audit findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CI packaging dry-run**: `build` job now runs `pnpm run package` (`vsce package`) after the build step, across the Node 22/24/26 matrix — validates the VSIX packaging pipeline on every PR/main run instead of only at release time. No upload/publish occurs.
 
 ### Fixed
+- **Security audit remediation**: Added a pnpm override pinning `nanoid` to `3.3.18` — the dev-only transitive dependency (`vitest` → `vite` → `postcss` → `nanoid`) was resolving to `3.3.16`, vulnerable to GHSA-2v37-7h3g-55p8 (infinite loop when `size` is zero, `<3.3.18`). Pinned to `3.3.18` rather than a `>=` floor to stay within `postcss`'s `^3.3.17` requirement (a `>=` range resolved to the ESM-only `nanoid@6`, breaking postcss). `pnpm audit --audit-level=low` now reports zero vulnerabilities.
 - Daily security audit workflow now manages a single tracking issue instead of creating duplicate issues each day; resolves all 41 stale bot-generated security alert issues
 - Updated CLAUDE.md to correctly document that `codeAnalysisService` uses `@babel/parser` (not TypeScript Compiler API)
 - **Security audit remediation**: Tightened pnpm overrides for `js-yaml` (`>=4.1.2` → `>=5.2.2`) and `brace-expansion` (`>=5.0.6` → `>=5.0.8`) — the prior ranges were resolving to vulnerable versions (`js-yaml@5.2.1`, `brace-expansion@5.0.7`) because they only set a floor without excluding the vulnerable window. `pnpm audit --audit-level=low` now reports zero vulnerabilities.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   fast-uri: '>=4.1.2'
   serialize-javascript: '>=7.0.5'
   postcss: '>=8.5.23'
+  nanoid: 3.3.18
   brace-expansion: '>=5.0.8'
   diff: '>=8.0.3'
   tmp: '>=0.2.7'
@@ -2476,8 +2477,8 @@ packages:
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -5996,7 +5997,7 @@ snapshots:
 
   mute-stream@0.0.8: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   napi-build-utils@2.0.0:
     optional: true
@@ -6238,7 +6239,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,7 @@ overrides:
   fast-uri: '>=4.1.2'
   serialize-javascript: '>=7.0.5'
   postcss: '>=8.5.23'
+  nanoid: '3.3.18'
   brace-expansion: '>=5.0.8'
   diff: '>=8.0.3'
   tmp: '>=0.2.7'


### PR DESCRIPTION
## Summary

Daily NPM-ecosystem vulnerability audit. `pnpm audit --audit-level=low` reported **1 high-severity** finding; this PR remediates it. All other checks pass.

### CVE remediated

| Advisory | Package | Severity | Path | Old → New | Fix |
| --- | --- | --- | --- | --- | --- |
| [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) | `nanoid` | high | `vitest → vite → postcss → nanoid` (dev-only, transitive) | `3.3.16 → 3.3.18` | pnpm override pinning `nanoid` to `3.3.18` |

**Advisory:** _nanoid: custom generators can loop indefinitely when size is zero_ (CWE-835). Vulnerable `<3.3.18`; patched `>=3.3.18`.

### Why pin exactly `3.3.18` (not a `>=` floor)

`postcss@8.5.25` requires `nanoid@^3.3.17`. An initial `nanoid: '>=3.3.18'` override resolved to `nanoid@6.0.1` — a major jump to an **ESM-only** release that breaks postcss's CommonJS `require('nanoid')`. Pinning to the exact patched `3.3.18` stays within `postcss`'s `^3.3.17` requirement while clearing the vulnerable window. This is the least-disruptive remedy (transitive dev-only CVE → pnpm override, no direct dependency bumps).

### Version verification (`npm view`)

- `npm view nanoid versions --json` confirms `3.3.18` exists on the registry and is the newest `3.x` release (`3.3.16`, `3.3.17`, `3.3.18` present).
- `npm view nanoid@3.3.18 version` → `3.3.18`; tarball resolves at `https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz`.
- `npm view postcss@latest dependencies.nanoid` → `^3.3.17` (satisfied by `3.3.18`).

### Compatibility

`pnpm install` after the change reports no ERESOLVE-style conflicts. The one remaining peer-dependency warning (`eslint-plugin-import` wanting `eslint ^…^9` vs installed `eslint 10.7.0`) is **pre-existing** and unrelated to this change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] CI/build tooling
- [x] Maintenance

## Verification

- [x] `pnpm run lint` — 0 errors (2 pre-existing warnings in `src/services/codeAnalysisService.ts`, untouched by this PR)
- [x] `pnpm run build` — build completed successfully
- [x] `pnpm run test:unit` — 13 files, 124 tests passed
- [ ] `pnpm run test:unit:coverage`
- [ ] `pnpm run test:integration` — skipped (requires display/xvfb; not available in this environment)
- [ ] Manual VS Code Extension Development Host check

### Final `pnpm audit --audit-level=low`

```
No known vulnerabilities found
```

### Build

```
✅ Build completed successfully!
📦 Main bundle (optimized): 469.23 KB
```

### Unit tests

```
 Test Files  13 passed (13)
      Tests  124 passed (124)
```

## Screenshots or recordings

N/A — dependency-only change, no VS Code UI change.

## Checklist

- [x] I updated docs or changelog entries when user-facing behavior changed. (CHANGELOG.md Unreleased → Fixed)
- [x] I avoided generated output in `dist/`, `out-test/`, and compiled `.js`/`.map` files.
- [x] I kept the PR focused and within the repository commit-size guidance. (3 files, 7 insertions, 4 deletions)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1qUyVgJHEdVRzB7XpzuBK)_